### PR TITLE
ignore uv.lock and bump pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,6 @@ cython_debug/
 # our binary format
 *.tar.gz
 *.litbin
+
+# Do not commit uv.lock.
+uv.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace


### PR DESCRIPTION
- Explicitly ignore `uv.lock` since this repository is a library
- Update pre-commit-hooks to `v6.0.0` to address deprecations warning
