### PR TITLE
Reduce dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "lightning-sdk >=2025.12.17",
+    "lightning-sdk >=2026.01.22",
     "litmodels >=0.1.8",
     "protobuf",
     "psutil",

--- a/src/litlogger/file_writer.py
+++ b/src/litlogger/file_writer.py
@@ -19,8 +19,6 @@ import struct
 import tarfile
 from typing import Dict, List
 
-import numpy as np
-
 from litlogger.api.artifacts_api import ArtifactsApi
 from litlogger.api.client import LitRestClient
 from litlogger.types import Metrics, MetricsTracker, MetricValue
@@ -91,7 +89,7 @@ class BinaryFileWriter:
                 }
 
                 header_in_bytes = json.dumps(header).encode("utf-8")
-                header_size_bytes = np.asarray(len(header_in_bytes), dtype=">u4").tobytes()
+                header_size_bytes = struct.pack(">I", len(header_in_bytes))
                 self.files[k].write(header_size_bytes)
                 self.files[k].write(header_in_bytes)
                 self.files[k].flush()


### PR DESCRIPTION
- Bumps SDK version to make use of reduced dependencies there
- replace numpy big-endian 4-byte unsigned integer conversion with struct.pack big-endian 4-byte unsigned integer (only numpy dependency)