### PR TITLE
retrieve previously logged experiment metadata

### DIFF
--- a/src/litlogger/__init__.py
+++ b/src/litlogger/__init__.py
@@ -26,7 +26,7 @@ from litlogger._preinit import pre_init_callable
 from litlogger.experiment import Experiment
 
 # Import SDK functions
-from litlogger.init import finish, init
+from litlogger.init import finish, get_metadata, init
 
 # Global variables
 experiment: Experiment | None = None
@@ -54,6 +54,7 @@ __all__ = [
     "log_model_artifact",
     "get_model_artifact",
     "finalize",
+    "get_metadata",
 ]
 
 try:

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -92,7 +92,6 @@ class Experiment:
         self._finalized = False
         self.store_step = store_step
         self.store_created_at = store_created_at
-        self._metadata = metadata
 
         # Initialize printer and stats tracking
         self._printer = Printer(verbose=verbose)
@@ -200,6 +199,16 @@ class Experiment:
             Teamspace: The teamspace object.
         """
         return self._teamspace
+
+    @property
+    def metadata(self) -> Dict[str, str]:
+        """Get the metadata associated with this experiment from the metrics stream.
+
+        Returns:
+            Dict[str, str]: The metadata dictionary with key-value pairs from code-defined tags.
+        """
+        tags = getattr(self._metrics_store, "tags", None) or []
+        return {tag.name: tag.value for tag in tags if tag.from_code}
 
     def log_metrics(self, metrics: Dict[str, float], step: int | None = None, **kwargs: float) -> None:
         """Log metrics to the experiment with background uploading.
@@ -559,5 +568,5 @@ class Experiment:
             teamspace=self._teamspace.name,
             url=self._url,
             version=self.version,
-            metadata=self._metadata,
+            metadata=self.metadata,
         )

--- a/src/litlogger/init.py
+++ b/src/litlogger/init.py
@@ -141,3 +141,20 @@ def finish(status: str | None = None) -> None:
         raise RuntimeError("You must call litlogger.init() before litlogger.finish()")
 
     litlogger.experiment.finalize(status)
+
+
+def get_metadata() -> Dict[str, str]:
+    """Get the metadata associated with the current experiment.
+
+    Returns:
+        Dict[str, str]: The metadata dictionary with key-value pairs from the metrics stream.
+
+    Raises:
+        RuntimeError: If litlogger.init() has not been called.
+    """
+    import litlogger
+
+    if litlogger.experiment is None:
+        raise RuntimeError("You must call litlogger.init() before litlogger.get_metadata()")
+
+    return litlogger.experiment.metadata

--- a/tests/integrations/test_standalone.py
+++ b/tests/integrations/test_standalone.py
@@ -504,7 +504,7 @@ def test_metadata_and_tags():
 @pytest.mark.cloud()
 def test_get_metadata():
     """Test get_metadata() function and experiment.metadata property."""
-    experiment_name = f"standalone_get_metadata_test-{uuid.uuid4().hex}"
+    experiment_name = f"meta_test-{uuid.uuid4().hex}"
     metadata = {
         "model": "GPT-2",
         "dataset": "WikiText",
@@ -553,7 +553,7 @@ def test_get_metadata():
 @pytest.mark.cloud()
 def test_get_metadata_empty():
     """Test get_metadata() when no metadata is provided."""
-    experiment_name = f"standalone_get_metadata_empty_test-{uuid.uuid4().hex}"
+    experiment_name = f"meta_empty_test-{uuid.uuid4().hex}"
 
     exp = litlogger.init(
         name=experiment_name,
@@ -588,7 +588,7 @@ def test_get_metadata_direct_experiment():
     """Test experiment.metadata property when using Experiment class directly."""
     from datetime import datetime, timezone
 
-    experiment_name = f"standalone_direct_metadata-{uuid.uuid4().hex}"
+    experiment_name = f"meta_direct-{uuid.uuid4().hex}"
     timestamp = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
     version_str = timestamp.replace("+00:00", "Z")
 


### PR DESCRIPTION
Allows scripts like 


```python
"""
Script 1: Log files, configs, and metadata using litlogger
"""

import json
import os

import litlogger

# Create some sample files to log
CONFIG_FILE = "/tmp/experiment_config.json"
DATA_FILE = "/tmp/sample_data.txt"

# Create a config file
config = {
    "model": "ResNet50",
    "learning_rate": 0.001,
    "batch_size": 32,
    "epochs": 100,
    "optimizer": "Adam",
}

with open(CONFIG_FILE, "w") as f:
    json.dump(config, f, indent=2)

# Create a sample data file
with open(DATA_FILE, "w") as f:
    f.write("Sample training data\n")
    f.write("epoch,loss,accuracy\n")
    f.write("1,0.5,0.7\n")
    f.write("2,0.3,0.85\n")
    f.write("3,0.1,0.95\n")

# Initialize experiment with metadata
litlogger.init(
    name="my-demo-experiment",
    metadata={
        "project": "image-classification",
        "dataset": "CIFAR10",
        "model": "ResNet50",
        "learning_rate": "0.001",
        "batch_size": "32",
    },
    verbose=True,
)

# Log some metrics
for epoch in range(10):
    loss = 1.0 / (epoch + 1)
    accuracy = 1 - loss
    litlogger.log_metrics({"train/loss": loss, "train/accuracy": accuracy}, step=epoch)

# Log files
print("\nLogging config file...")
litlogger.log_file(CONFIG_FILE, verbose=True)

print("\nLogging data file...")
litlogger.log_file(DATA_FILE, verbose=True)

# Finalize the experiment
litlogger.finalize()

print("\nExperiment logged successfully!")

```

and 
```python
"""
Script 2: Fetch logged files, configs, and metadata using litlogger

This script retrieves data that was logged in the first script.
"""

import json
import os

import litlogger

# Initialize with the SAME experiment name to access logged data
# You can also pass the exact version if you want a specific run
litlogger.init(
    name="my-demo-experiment",
    verbose=True,
)

# Fetch metadata from the experiment
print("\n--- Fetching Metadata ---")
metadata = litlogger.get_metadata()
print(f"Experiment metadata: {json.dumps(metadata, indent=2)}")

# You can also access metadata via the experiment object
print(f"\nMetadata via experiment.metadata: {litlogger.experiment.metadata}")

# Define where to download files locally
RETRIEVED_CONFIG = "/tmp/retrieved_config.json"
RETRIEVED_DATA = "/tmp/retrieved_data.txt"

# Fetch the config file
print("\n--- Fetching Config File ---")
config_path = litlogger.get_file(
    path=RETRIEVED_CONFIG,
    remote_path="experiment_config.json",  # Basename of the original file
    verbose=True,
)

if os.path.exists(config_path):
    with open(config_path, "r") as f:
        config = json.load(f)
    print(f"Retrieved config: {json.dumps(config, indent=2)}")
else:
    print(f"Config file not found at {config_path}")

# Fetch the data file
print("\n--- Fetching Data File ---")
data_path = litlogger.get_file(
    path=RETRIEVED_DATA,
    remote_path="sample_data.txt",  # Basename of the original file
    verbose=True,
)

if os.path.exists(data_path):
    with open(data_path, "r") as f:
        data = f.read()
    print(f"Retrieved data:\n{data}")
else:
    print(f"Data file not found at {data_path}")

# Finalize
litlogger.finalize()
```

to work for retrieving logged metadata.