### PR TITLE
Use the correct cluster for media uploads

### DIFF
--- a/src/litlogger/api/media_api.py
+++ b/src/litlogger/api/media_api.py
@@ -106,7 +106,7 @@ class MediaApi:
         headers = {"Content-Type": mime_type} if mime_type else None
         teamspace._teamspace_api.upload_file(
             teamspace_id=teamspace.id,
-            cloud_account=teamspace.default_cloud_account,
+            cloud_account=media.cluster_id,
             file_path=file_path,
             remote_path=media.storage_path,
             headers=headers,

--- a/tests/unittests/api/test_media_api.py
+++ b/tests/unittests/api/test_media_api.py
@@ -37,11 +37,10 @@ class TestMediaApi:
 
         mock_teamspace = MagicMock()
         mock_teamspace.id = "ts-123"
-        mock_teamspace.default_cloud_account = "acc-456"
         mock_teamspace._teamspace_api = MagicMock()
 
         media = SimpleNamespace(storage_path="media/abc.png", id="media-1")
-        create_response = SimpleNamespace(media=media, already_exists=False)
+        create_response = SimpleNamespace(media=media, already_exists=False, cluster_id="acc-456")
         mock_client.lit_logger_service_create_lit_logger_media.return_value = create_response
 
         updated_media = SimpleNamespace(id="media-1", storage_path="media/abc.png")
@@ -78,11 +77,10 @@ class TestMediaApi:
 
         mock_teamspace = MagicMock()
         mock_teamspace.id = "ts-123"
-        mock_teamspace.default_cloud_account = "acc-456"
         mock_teamspace._teamspace_api = MagicMock()
 
         media = SimpleNamespace(storage_path="media/abc.png", id="media-1")
-        create_response = SimpleNamespace(media=media, already_exists=True)
+        create_response = SimpleNamespace(media=media, already_exists=True, cluster_id="acc-456")
         mock_client.lit_logger_service_create_lit_logger_media.return_value = create_response
 
         with tempfile.NamedTemporaryFile(mode="wb", delete=False, suffix=".png") as f:
@@ -110,7 +108,6 @@ class TestMediaApi:
         api = MediaApi(client=MagicMock())
         mock_teamspace = MagicMock()
         mock_teamspace.id = "ts-123"
-        mock_teamspace.default_cloud_account = "acc-456"
         mock_teamspace._teamspace_api = MagicMock()
 
         with pytest.raises(FileNotFoundError, match="file not found"):

--- a/tests/unittests/api/test_media_api.py
+++ b/tests/unittests/api/test_media_api.py
@@ -39,8 +39,8 @@ class TestMediaApi:
         mock_teamspace.id = "ts-123"
         mock_teamspace._teamspace_api = MagicMock()
 
-        media = SimpleNamespace(storage_path="media/abc.png", id="media-1")
-        create_response = SimpleNamespace(media=media, already_exists=False, cluster_id="acc-456")
+        media = SimpleNamespace(storage_path="media/abc.png", id="media-1", cluster_id="acc-456")
+        create_response = SimpleNamespace(media=media, already_exists=False)
         mock_client.lit_logger_service_create_lit_logger_media.return_value = create_response
 
         updated_media = SimpleNamespace(id="media-1", storage_path="media/abc.png")
@@ -79,8 +79,8 @@ class TestMediaApi:
         mock_teamspace.id = "ts-123"
         mock_teamspace._teamspace_api = MagicMock()
 
-        media = SimpleNamespace(storage_path="media/abc.png", id="media-1")
-        create_response = SimpleNamespace(media=media, already_exists=True, cluster_id="acc-456")
+        media = SimpleNamespace(storage_path="media/abc.png", id="media-1", cluster_id="acc-456")
+        create_response = SimpleNamespace(media=media, already_exists=True)
         mock_client.lit_logger_service_create_lit_logger_media.return_value = create_response
 
         with tempfile.NamedTemporaryFile(mode="wb", delete=False, suffix=".png") as f:


### PR DESCRIPTION
When we create a media entry, we associate it with the same cluster as the experiment (i.e. the studio's cluster). However, when we actually upload the media, we upload it to the teamspace's default cluster. These can differ, which results in us trying to download the files from the wrong cluster.

Since the media's cluster ID is correct and part of the creation response then let's just use that rather than the teamspace's default.