### PR TITLE
Add experimental `log_media` method

### DIFF
--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -573,6 +573,7 @@ class Experiment:
         step: int | None = None,
         epoch: int | None = None,
         caption: str | None = None,
+        verbose: bool = False,
     ) -> None:
         """Upload a media file (image, text, etc.) to the experiment.
 
@@ -583,6 +584,7 @@ class Experiment:
             step: Optional training step.
             epoch: Optional training epoch.
             caption: Optional caption for the media.
+            verbose: Whether to print a confirmation message after upload.
 
         Raises:
             ValueError: If the file type cannot be determined or is not supported.
@@ -620,7 +622,8 @@ class Experiment:
             caption=caption,
         )
         self._stats.media_logged += 1
-        self._printer.media_logged(path, step)
+        if verbose:
+            self._printer.media_logged(path, step)
 
     def print_url(self) -> None:
         """Print the experiment URL and initialization info with styled output."""

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -15,6 +15,7 @@
 
 import atexit
 import contextlib
+import mimetypes
 import os
 import signal
 import sys
@@ -25,20 +26,19 @@ from threading import Event
 from time import sleep
 from types import FrameType
 from typing import TYPE_CHECKING, Any, Dict, List, Union
-import mimetypes
 
 from lightning_sdk.lightning_cloud.openapi import V1MediaType
 
 from litlogger.api.artifacts_api import ArtifactsApi
 from litlogger.api.auth_api import AuthApi
-from litlogger.api.metrics_api import MetricsApi
 from litlogger.api.media_api import MediaApi
+from litlogger.api.metrics_api import MetricsApi
 from litlogger.api.utils import _resolve_teamspace, build_experiment_url, get_accessible_url, get_guest_url
 from litlogger.artifacts import Artifact, Model, ModelArtifact
 from litlogger.background import _BackgroundThread
 from litlogger.capture import rerun_and_record
 from litlogger.printer import Printer, RunStats
-from litlogger.types import Metrics, MetricValue, MediaType
+from litlogger.types import MediaType, Metrics, MetricValue
 
 if TYPE_CHECKING:
     from lightning_sdk import Teamspace
@@ -569,7 +569,7 @@ class Experiment:
     def log_media(
         self,
         path: str,
-        type: MediaType | None = None,
+        kind: MediaType | None = None,
         step: int | None = None,
         epoch: int | None = None,
         caption: str | None = None,
@@ -578,7 +578,7 @@ class Experiment:
 
         Args:
             path: Local path to the media file.
-            type: Type of media (MediaType.IMAGE or MediaType.TEXT).
+            kind: Type of media (MediaType.IMAGE or MediaType.TEXT).
                   If None, attempts to guess from file extension or mime type.
             step: Optional training step.
             epoch: Optional training epoch.
@@ -593,10 +593,10 @@ class Experiment:
 
         media_type = V1MediaType.UNSPECIFIED
 
-        if type is not None:
-            if type == MediaType.IMAGE:
+        if kind is not None:
+            if kind == MediaType.IMAGE:
                 media_type = V1MediaType.IMAGE
-            elif type == MediaType.TEXT:
+            elif kind == MediaType.TEXT:
                 media_type = V1MediaType.TEXT
         else:
             mime_type, _ = mimetypes.guess_type(path)

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -568,6 +568,7 @@ class Experiment:
 
     def log_media(
         self,
+        name: str,
         path: str,
         kind: MediaType | None = None,
         step: int | None = None,
@@ -578,6 +579,7 @@ class Experiment:
         """Upload a media file (image, text, etc.) to the experiment.
 
         Args:
+            name: Name of the media.
             path: Local path to the media file.
             kind: Type of media (MediaType.IMAGE or MediaType.TEXT).
                   If None, attempts to guess from file extension or mime type.
@@ -615,7 +617,7 @@ class Experiment:
             experiment_id=self._metrics_store.id,
             teamspace=self._teamspace,
             file_path=path,
-            name=os.path.basename(path),
+            name=name,
             media_type=media_type,
             step=step,
             epoch=epoch,

--- a/src/litlogger/logger.py
+++ b/src/litlogger/logger.py
@@ -423,7 +423,7 @@ else:
         def log_media(
             self,
             path: str,
-            type: MediaType | None = None,
+            kind: MediaType | None = None,
             step: int | None = None,
             epoch: int | None = None,
             caption: str | None = None,
@@ -432,7 +432,7 @@ else:
 
             Args:
                 path: Local path to the media file.
-                type: Type of media (MediaType.IMAGE or MediaType.TEXT).
+                kind: Kind of media (MediaType.IMAGE or MediaType.TEXT).
                       If None, attempts to guess from file extension or mime type.
                 step: Optional training step.
                 epoch: Optional training epoch.
@@ -440,4 +440,4 @@ else:
             """
             self._is_ready = True
             self._store_step = True
-            self.experiment.log_media(path, type, step, epoch, caption)
+            self.experiment.log_media(path, kind, step, epoch, caption)

--- a/src/litlogger/logger.py
+++ b/src/litlogger/logger.py
@@ -422,6 +422,7 @@ else:
 
         def log_media(
             self,
+            name: str,
             path: str,
             kind: MediaType | None = None,
             step: int | None = None,
@@ -432,6 +433,7 @@ else:
             """Log a media file to the experiment.
 
             Args:
+                name: Name of the media.
                 path: Local path to the media file.
                 kind: Kind of media (MediaType.IMAGE or MediaType.TEXT).
                       If None, attempts to guess from file extension or mime type.
@@ -442,4 +444,4 @@ else:
             """
             self._is_ready = True
             self._store_step = True
-            self.experiment.log_media(path, kind, step, epoch, caption, verbose)
+            self.experiment.log_media(name, path, kind, step, epoch, caption, verbose)

--- a/src/litlogger/logger.py
+++ b/src/litlogger/logger.py
@@ -427,6 +427,7 @@ else:
             step: int | None = None,
             epoch: int | None = None,
             caption: str | None = None,
+            verbose: bool = False,
         ) -> None:
             """Log a media file to the experiment.
 
@@ -437,7 +438,8 @@ else:
                 step: Optional training step.
                 epoch: Optional training epoch.
                 caption: Optional caption.
+                verbose: Whether to print a confirmation message after upload.
             """
             self._is_ready = True
             self._store_step = True
-            self.experiment.log_media(path, kind, step, epoch, caption)
+            self.experiment.log_media(path, kind, step, epoch, caption, verbose)

--- a/src/litlogger/logger.py
+++ b/src/litlogger/logger.py
@@ -28,6 +28,7 @@ from typing_extensions import override
 
 from litlogger.experiment import Experiment
 from litlogger.generator import _create_name
+from litlogger.types import MediaType
 
 _base_classes = []
 
@@ -418,3 +419,25 @@ else:
             self._is_ready = True
             self._store_step = True
             self.experiment.log_file(path)
+
+        def log_media(
+            self,
+            path: str,
+            type: MediaType | None = None,
+            step: int | None = None,
+            epoch: int | None = None,
+            caption: str | None = None,
+        ) -> None:
+            """Log a media file to the experiment.
+
+            Args:
+                path: Local path to the media file.
+                type: Type of media (MediaType.IMAGE or MediaType.TEXT).
+                      If None, attempts to guess from file extension or mime type.
+                step: Optional training step.
+                epoch: Optional training epoch.
+                caption: Optional caption.
+            """
+            self._is_ready = True
+            self._store_step = True
+            self.experiment.log_media(path, type, step, epoch, caption)

--- a/src/litlogger/printer.py
+++ b/src/litlogger/printer.py
@@ -121,6 +121,7 @@ class RunStats:
 
     metrics_logged: int = 0
     artifacts_logged: int = 0
+    media_logged: int = 0
     models_logged: int = 0
     # Store recent values for sparklines (metric_name -> list of values)
     metrics_history: Dict[str, List[float]] = field(default_factory=dict)
@@ -406,6 +407,8 @@ class Printer:
             rows.append(("Metrics logged", f"{stats.metrics_logged:,}"))
         if stats.artifacts_logged > 0:
             rows.append(("Artifacts", f"{stats.artifacts_logged:,}"))
+        if stats.media_logged > 0:
+            rows.append(("Media logged", f"{stats.media_logged:,}"))
         if stats.models_logged > 0:
             rows.append(("Models", f"{stats.models_logged:,}"))
 
@@ -476,6 +479,19 @@ class Printer:
         check = self.emoji("check") or "✓"
         display_path = remote_path or path
         self._echo(f"{self.success(check)} Logged {self.files(display_path)}")
+
+    def media_logged(self, path: str, step: int | None = None) -> None:
+        """Print media upload confirmation.
+
+        Example:
+            litlogger: ✓ Logged output.png (step 100)
+        """
+        if not self.verbose:
+            return
+
+        check = self.emoji("check") or "✓"
+        step_str = f" (step {step})" if step is not None else ""
+        self._echo(f"{self.success(check)} Logged {self.files(path)}{step_str}")
 
     def artifact_retrieved(self, path: str) -> None:
         """Print artifact download confirmation.

--- a/src/litlogger/types.py
+++ b/src/litlogger/types.py
@@ -33,6 +33,13 @@ class PhaseType(str, Enum):
     STOPPED = "stopped"
 
 
+class MediaType(str, Enum):
+    """Type of media to upload."""
+
+    IMAGE = "image"
+    TEXT = "text"
+
+
 @dataclass
 class MetricValue:
     """A single metric value with optional step and timestamp.

--- a/tests/unittests/test_experiment.py
+++ b/tests/unittests/test_experiment.py
@@ -699,7 +699,7 @@ class TestExperimentLogMedia:
         from litlogger.types import MediaType
 
         with patch("os.path.exists", return_value=True):
-            Experiment.log_media(exp, "/path/to/image.png", kind=MediaType.IMAGE)
+            Experiment.log_media(exp, "image", "/path/to/image.png", kind=MediaType.IMAGE)
 
         # Verify upload_media called with correct args
         exp._media_api.upload_media.assert_called_once()
@@ -722,7 +722,7 @@ class TestExperimentLogMedia:
         from litlogger.experiment import Experiment
 
         with patch("os.path.exists", return_value=True):
-            Experiment.log_media(exp, "/path/to/image.jpg")
+            Experiment.log_media(exp, "image", "/path/to/image.jpg")
 
         _, kwargs = exp._media_api.upload_media.call_args
         assert kwargs["media_type"] == V1MediaType.IMAGE
@@ -742,7 +742,7 @@ class TestExperimentLogMedia:
         from litlogger.experiment import Experiment
 
         with patch("os.path.exists", return_value=True):
-            Experiment.log_media(exp, "/path/to/readme.txt")
+            Experiment.log_media(exp, "file", "/path/to/file.txt")
 
         _, kwargs = exp._media_api.upload_media.call_args
         assert kwargs["media_type"] == V1MediaType.TEXT
@@ -766,7 +766,7 @@ class TestExperimentLogMedia:
             patch("mimetypes.guess_type", return_value=("application/zip", None)),
             pytest.raises(ValueError, match="Unsupported media type for file: /path/to/file.txt"),
         ):
-            Experiment.log_media(exp, "/path/to/file.txt")
+            Experiment.log_media(exp, "file", "/path/to/file.txt")
 
     def test_log_media_raises_file_not_found(self):
         """Test log_media raises FileNotFoundError."""
@@ -778,4 +778,4 @@ class TestExperimentLogMedia:
         from litlogger.experiment import Experiment
 
         with patch("os.path.exists", return_value=False), pytest.raises(FileNotFoundError):
-            Experiment.log_media(exp, "/non/existent/file.png")
+            Experiment.log_media(exp, "file", "/non/existent/file.png")

--- a/tests/unittests/test_experiment.py
+++ b/tests/unittests/test_experiment.py
@@ -677,6 +677,7 @@ class TestExperimentInitialization:
         """Test that signal handler method exists."""
         assert hasattr(experiment_module.Experiment, "_signal_handler")
 
+
 class TestExperimentLogMedia:
     """Test log_media method."""
 
@@ -691,13 +692,14 @@ class TestExperimentLogMedia:
         exp._stats.media_logged = 0
 
         # Import MediaType from types
-        from litlogger.types import MediaType
+        from unittest.mock import patch
+
         from lightning_sdk.lightning_cloud.openapi import V1MediaType
         from litlogger.experiment import Experiment
-        from unittest.mock import patch
-        
+        from litlogger.types import MediaType
+
         with patch("os.path.exists", return_value=True):
-            Experiment.log_media(exp, "/path/to/image.png", type=MediaType.IMAGE)
+            Experiment.log_media(exp, "/path/to/image.png", kind=MediaType.IMAGE)
 
         # Verify upload_media called with correct args
         exp._media_api.upload_media.assert_called_once()
@@ -714,12 +716,13 @@ class TestExperimentLogMedia:
         exp._stats = MagicMock()
         exp._stats.media_logged = 0
 
+        from unittest.mock import patch
+
         from lightning_sdk.lightning_cloud.openapi import V1MediaType
         from litlogger.experiment import Experiment
-        from unittest.mock import patch
-        
+
         with patch("os.path.exists", return_value=True):
-             Experiment.log_media(exp, "/path/to/image.jpg")
+            Experiment.log_media(exp, "/path/to/image.jpg")
 
         _, kwargs = exp._media_api.upload_media.call_args
         assert kwargs["media_type"] == V1MediaType.IMAGE
@@ -733,12 +736,13 @@ class TestExperimentLogMedia:
         exp._stats = MagicMock()
         exp._stats.media_logged = 0
 
+        from unittest.mock import patch
+
         from lightning_sdk.lightning_cloud.openapi import V1MediaType
         from litlogger.experiment import Experiment
-        from unittest.mock import patch
-        
+
         with patch("os.path.exists", return_value=True):
-             Experiment.log_media(exp, "/path/to/readme.txt")
+            Experiment.log_media(exp, "/path/to/readme.txt")
 
         _, kwargs = exp._media_api.upload_media.call_args
         assert kwargs["media_type"] == V1MediaType.TEXT
@@ -752,25 +756,26 @@ class TestExperimentLogMedia:
         exp._stats = MagicMock()
         exp._stats.media_logged = 0
 
-        from lightning_sdk.lightning_cloud.openapi import V1MediaType
-        from litlogger.experiment import Experiment
         from unittest.mock import patch
+
         import pytest
-        
-        with patch("os.path.exists", return_value=True):
-            with patch("mimetypes.guess_type", return_value=("application/zip", None)):
-                with pytest.raises(ValueError):
-                    Experiment.log_media(exp, "/path/to/file.txt")
+        from litlogger.experiment import Experiment
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("mimetypes.guess_type", return_value=("application/zip", None)),
+            pytest.raises(ValueError, match="Unsupported media type for file: /path/to/file.txt"),
+        ):
+            Experiment.log_media(exp, "/path/to/file.txt")
 
     def test_log_media_raises_file_not_found(self):
         """Test log_media raises FileNotFoundError."""
         exp = MagicMock()
-        
-        from litlogger.experiment import Experiment
+
         from unittest.mock import patch
+
         import pytest
+        from litlogger.experiment import Experiment
 
-        with patch("os.path.exists", return_value=False):
-            with pytest.raises(FileNotFoundError):
-                Experiment.log_media(exp, "/non/existent/file.png")
-
+        with patch("os.path.exists", return_value=False), pytest.raises(FileNotFoundError):
+            Experiment.log_media(exp, "/non/existent/file.png")

--- a/tests/unittests/test_logger.py
+++ b/tests/unittests/test_logger.py
@@ -57,6 +57,6 @@ def test_log_media():
     logger = object.__new__(LightningLogger)
     logger._experiment = MagicMock()
 
-    logger.log_media("test.png", kind=MediaType.IMAGE, step=10, caption="Test caption")
+    logger.log_media("image", "test.png", kind=MediaType.IMAGE, step=10, caption="Test caption")
 
-    logger._experiment.log_media.assert_called_once_with("test.png", MediaType.IMAGE, 10, None, "Test caption")
+    logger._experiment.log_media.assert_called_once_with("image", "test.png", MediaType.IMAGE, 10, None, "Test caption")

--- a/tests/unittests/test_logger.py
+++ b/tests/unittests/test_logger.py
@@ -47,3 +47,19 @@ def test_log_file():
     # Call log_file and verify it delegates to the experiment
     logger.log_file("test.txt")
     logger._experiment.log_file.assert_called_once_with("test.txt")
+
+
+def test_log_media():
+    """Test that LightningLogger has a log_media method."""
+    from litlogger import LightningLogger
+    from litlogger.types import MediaType
+
+    logger = object.__new__(LightningLogger)
+    logger._experiment = MagicMock()
+
+    logger.log_media("test.png", type=MediaType.IMAGE, step=10, caption="Test caption")
+    
+    logger._experiment.log_media.assert_called_once_with(
+        "test.png", MediaType.IMAGE, 10, None, "Test caption"
+    )
+

--- a/tests/unittests/test_logger.py
+++ b/tests/unittests/test_logger.py
@@ -57,9 +57,6 @@ def test_log_media():
     logger = object.__new__(LightningLogger)
     logger._experiment = MagicMock()
 
-    logger.log_media("test.png", type=MediaType.IMAGE, step=10, caption="Test caption")
-    
-    logger._experiment.log_media.assert_called_once_with(
-        "test.png", MediaType.IMAGE, 10, None, "Test caption"
-    )
+    logger.log_media("test.png", kind=MediaType.IMAGE, step=10, caption="Test caption")
 
+    logger._experiment.log_media.assert_called_once_with("test.png", MediaType.IMAGE, 10, None, "Test caption")


### PR DESCRIPTION
Add a new `log_media` method which can be used for logging files (images, text) at a specific point in the experiment. These will appear under the experiment's "media" tab.

Examples:

```python
experiment = litlogger.init()
experiment.log_media("my output", "output.png", step=10, epoch=20) # Guess media type from file
experiment.log_media("my output", "output.foo", type=MediaType.IMAGE, step=10, epoch=20) # Explicit media type
```

Unlike `log_metrics`, `step` and `epoch` must be explicitly provided by the user, for now.