### PR TITLE
Remove versioning

### DIFF
--- a/src/litlogger/api/metrics_api.py
+++ b/src/litlogger/api/metrics_api.py
@@ -153,14 +153,12 @@ class MetricsApi:
         self,
         teamspace_id: str,
         name: str,
-        version_number: int | None = None,
     ) -> Any | None:
         """Fetch an experiment (metrics stream) by name.
 
         Args:
             teamspace_id: The teamspace ID.
             name: The experiment name.
-            version_number: Optional version number. If not specified, returns the latest version.
 
         Returns:
             The metrics stream object for the experiment, or None if not found.
@@ -176,21 +174,12 @@ class MetricsApi:
         if not matching:
             return None
 
-        # If version_number specified, find that specific version
-        if version_number is not None:
-            for ms in matching:
-                if ms.version_number == version_number:
-                    return ms
-            return None
-
-        # Return the latest version (highest version_number)
-        return max(matching, key=lambda ms: ms.version_number)
+        return matching[0]
 
     def get_or_create_experiment_metrics(
         self,
         teamspace_id: str,
         name: str,
-        version: str,
         metadata: Dict[str, str] | None = None,
         light_color: str | None = None,
         dark_color: str | None = None,
@@ -202,7 +191,6 @@ class MetricsApi:
         Args:
             teamspace_id: The teamspace ID.
             name: Experiment name.
-            version: Experiment version (used only when creating).
             metadata: Optional metadata tags (used only when creating).
             light_color: Light mode color (used only when creating).
             dark_color: Dark mode color (used only when creating).
@@ -220,7 +208,6 @@ class MetricsApi:
         new_experiment = self.create_experiment_metrics(
             teamspace_id=teamspace_id,
             name=name,
-            version=version,
             metadata=metadata,
             light_color=light_color,
             dark_color=dark_color,
@@ -233,7 +220,6 @@ class MetricsApi:
         self,
         teamspace_id: str,
         name: str,
-        version: str,
         metadata: Dict[str, str] | None = None,
         light_color: str | None = None,
         dark_color: str | None = None,
@@ -245,7 +231,6 @@ class MetricsApi:
         Args:
             teamspace_id: The teamspace ID.
             name: Experiment name.
-            version: Experiment version.
             metadata: Optional metadata tags.
             light_color: Light mode color.
             dark_color: Dark mode color.
@@ -255,8 +240,8 @@ class MetricsApi:
         Returns:
             The created metrics store object.
         """
-        # Generate colors based on name + version for consistent unique colors per version
-        random_light_color, random_dark_color = _create_colors(name, version)
+        # Generate colors based on name for consistent unique colors
+        random_light_color, random_dark_color = _create_colors(name)
 
         # Convert metadata to tags
         tags = []
@@ -278,7 +263,6 @@ class MetricsApi:
             project_id=teamspace_id,
             body=LitLoggerServiceCreateMetricsStreamBody(
                 name=name,
-                version=version,
                 cloudspace_id=cloudspace_id,
                 app_id=app_id,
                 work_id=work_id,

--- a/src/litlogger/api/utils.py
+++ b/src/litlogger/api/utils.py
@@ -81,7 +81,6 @@ def build_experiment_url(
     owner_name: str,
     teamspace_name: str,
     experiment_name: str,
-    version: str,
 ) -> str:
     """Build the direct URL to an experiment.
 
@@ -89,13 +88,12 @@ def build_experiment_url(
         owner_name: Owner username or org name.
         teamspace_name: Teamspace name.
         experiment_name: Experiment name.
-        version: Experiment version.
 
     Returns:
         str: The experiment URL.
     """
     cloud_url = _get_cloud_url()
-    return f"{cloud_url}/{owner_name}/{teamspace_name}/experiments/{experiment_name}%20-%20v{version}"
+    return f"{cloud_url}/{owner_name}/{teamspace_name}/experiments/{experiment_name}"
 
 
 _MAP_PLUGIN_ID_TO_APP = {"job_run_plugin": "jobs", "distributed_plugin": "mmt", "litdata": "litdata"}

--- a/src/litlogger/background.py
+++ b/src/litlogger/background.py
@@ -46,7 +46,6 @@ class _BackgroundThread(Thread):
         stop_event: Event that, when set, requests a graceful shutdown.
         done_event: Event set once all pending metrics have been flushed and the upload completed.
         log_dir: Local directory where temporary metric files are written.
-        version: Experiment version used to name the archive on upload.
         store_step: Whether to persist the step field with each value.
         store_created_at: Whether to persist the timestamp for each value.
         rate_limiting_interval: Minimum seconds between consecutive network sends.
@@ -64,7 +63,6 @@ class _BackgroundThread(Thread):
         stop_event: Event,
         done_event: Event,
         log_dir: str,
-        version: str,
         store_step: bool,
         store_created_at: bool,
         rate_limiting_interval: int = 1,
@@ -90,7 +88,6 @@ class _BackgroundThread(Thread):
 
         self.file_store = BinaryFileWriter(
             log_dir=log_dir,
-            version=version,
             store_step=store_step,
             store_created_at=store_created_at,
             teamspace_id=teamspace_id,

--- a/src/litlogger/colors.py
+++ b/src/litlogger/colors.py
@@ -223,26 +223,22 @@ _DARK_THEME_COLORS = [
 ]
 
 
-def _create_colors(name: str | None = None, version: str | None = None) -> tuple[str, str]:
+def _create_colors(name: str | None = None) -> tuple[str, str]:
     """Return a pair of (light_mode_color, dark_mode_color).
 
-    If name and version are provided, returns a deterministic color based on their hash.
-    This ensures different versions of the same experiment get different colors,
-    while the same version always gets the same color.
+    If name is provided, returns a deterministic color based on it's hash.
+    This ensures different of the same experiment get different colors.
 
-    If neither is provided, falls back to random selection for backwards compatibility.
+    If it is not provided, falls back to random selection for backwards compatibility.
 
     Args:
         name: Optional experiment name
-        version: Optional version string
-
     Returns:
         Tuple of (light_mode_color, dark_mode_color) hex strings
     """
-    if name is not None and version is not None:
-        # Use hash of name + version for deterministic but unique color assignment
-        hash_input = f"{name}:{version}"
-        hash_value = int(hashlib.md5(hash_input.encode()).hexdigest(), 16)
+    if name is not None:
+        # Use hash of namefor deterministic but unique color assignment
+        hash_value = int(hashlib.md5(name.encode()).hexdigest(), 16)
         idx = hash_value % len(_DARK_THEME_COLORS)
     else:
         # Fallback to random for backwards compatibility

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -59,7 +59,6 @@ class Experiment:
     def __init__(
         self,
         name: str,
-        version: str,
         log_dir: str = "lightning_logs",
         save_logs: bool = False,
         teamspace: Union[str, "Teamspace"] | None = None,
@@ -76,7 +75,6 @@ class Experiment:
 
         Args:
             name: A human-friendly name for your experiment.
-            version: An experiment version identifier (typically a timestamp string).
             log_dir: Local directory where temporary logs/artifacts are stored. Defaults to "lightning_logs".
             save_logs: If True, capture and upload terminal output as a file artifact. Defaults to False.
             teamspace: Teamspace in which to create and display the charts. If None, uses your default teamspace.
@@ -90,7 +88,6 @@ class Experiment:
             verbose: If True, print styled console output. Defaults to True.
         """
         self.name = name
-        self.version = version
         self.save_logs = save_logs
         self._done_event = Event()
         self._finalized = False
@@ -123,7 +120,6 @@ class Experiment:
         self._metrics_store, _ = self._metrics_api.get_or_create_experiment_metrics(
             teamspace_id=self._teamspace.id,
             name=self.name,
-            version=self.version,
             metadata=metadata,
             light_color=light_color,
             dark_color=dark_color,
@@ -131,13 +127,12 @@ class Experiment:
             store_created_at=bool(store_created_at),
         )
 
-        # Build URLs using API - use version_number from metrics store for clean URLs
+        # Build URLs using API
         if is_authenticated:
             self._url = build_experiment_url(
                 owner_name=self._teamspace.owner.name,
                 teamspace_name=self._teamspace.name,
                 experiment_name=self.name,
-                version=self._metrics_store.version_number,
             )
         else:
             self._url = get_guest_url(self._auth_api)
@@ -163,7 +158,6 @@ class Experiment:
             stop_event=self._stop_event,
             done_event=self._done_event,
             log_dir=log_dir,
-            version=version,
             store_step=store_step,
             store_created_at=store_created_at,
             rate_limiting_interval=rate_limiting_interval,
@@ -462,13 +456,13 @@ class Experiment:
         Args:
             path: Path to the local model file or directory to upload.
             verbose: Whether to show progress bar during upload. Defaults to False.
-            version: Optional version string for the model. Defaults to the experiment version.
+            version: Optional version string for the model.
         """
         model_artifact = ModelArtifact(
             path=path,
             experiment_name=self.name,
             teamspace=self._teamspace,
-            version=version or self.version,
+            version=version or "latest",
             verbose=verbose,
         )
         model_artifact.log()
@@ -485,7 +479,7 @@ class Experiment:
         Args:
             path: Path where the model should be saved locally. Directories are created if needed.
             verbose: Whether to show progress bar during download. Defaults to False.
-            version: Optional version string for the model. Defaults to the experiment version.
+            version: Optional version string for the model.
 
         Returns:
             str: The local path where the model was saved (same as the input path).
@@ -494,7 +488,7 @@ class Experiment:
             path=path,
             experiment_name=self.name,
             teamspace=self._teamspace,
-            version=version or self.version,
+            version=version or "latest",
             verbose=verbose,
         )
         result = model_artifact.get()
@@ -521,7 +515,7 @@ class Experiment:
             model: The model object to save and upload (e.g., torch.nn.Module, LightningModule).
             staging_dir: Optional local directory for staging the model before upload. If None, uses a temp directory.
             verbose: Whether to show progress bar during upload. Defaults to False.
-            version: Optional version string for the model. Defaults to the experiment version.
+            version: Optional version string for the model.
             metadata: Optional metadata dictionary to store with the model (e.g., hyperparameters, metrics).
 
         Returns:
@@ -531,7 +525,7 @@ class Experiment:
             model=model,
             experiment_name=self.name,
             teamspace=self._teamspace,
-            version=version or self.version,
+            version=version or "latest",
             verbose=verbose,
             metadata=metadata,
             staging_dir=staging_dir,
@@ -557,7 +551,7 @@ class Experiment:
             model=None,  # Not needed for loading
             experiment_name=self.name,
             teamspace=self._teamspace,
-            version=version or self.version,
+            version=version or "latest",
             verbose=verbose,
             staging_dir=staging_dir,
         )
@@ -633,6 +627,5 @@ class Experiment:
             name=self.name,
             teamspace=self._teamspace.name,
             url=self._url,
-            version=self.version,
             metadata=self.metadata,
         )

--- a/src/litlogger/file_writer.py
+++ b/src/litlogger/file_writer.py
@@ -24,14 +24,6 @@ from litlogger.api.client import LitRestClient
 from litlogger.types import Metrics, MetricsTracker, MetricValue
 
 
-def _sanitize_version_for_path(version: str) -> str:
-    """Sanitize version string for use in file paths.
-
-    Windows doesn't allow colons in filenames, so replace them with hyphens.
-    """
-    return version.replace(":", "-")
-
-
 class BinaryFileWriter:
     """Write metrics to per-series .litbin files and upload them as a single archive.
 
@@ -43,7 +35,6 @@ class BinaryFileWriter:
     def __init__(
         self,
         log_dir: str,
-        version: str,
         store_step: bool,
         store_created_at: bool,
         teamspace_id: str,
@@ -52,7 +43,6 @@ class BinaryFileWriter:
         client: LitRestClient | None = None,
     ) -> None:
         self.log_dir = log_dir
-        self.version = version
         self.store_step = store_step
         self.store_created_at = store_created_at
 
@@ -149,8 +139,7 @@ class BinaryFileWriter:
         filenames = [fn for fn in os.listdir(self.log_dir) if fn.endswith(".litbin")]
 
         # Create and upload tar ball
-        safe_version = _sanitize_version_for_path(self.version)
-        file_path = os.path.join(self.log_dir, f"{safe_version}.tar.gz")
+        file_path = os.path.join(self.log_dir, f"{self.metrics_store_id}.tar.gz")
         with tarfile.open(file_path, "w:gz") as tar:
             for filename in filenames:
                 tar.add(

--- a/src/litlogger/init.py
+++ b/src/litlogger/init.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Initialize litlogger experiment for standalone usage (without PyTorch Lightning)."""
 
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Union
 
@@ -85,18 +84,12 @@ def init(
     # default to 'project' if no meaningful name was found
     experiment_project_name = experiment_project_name or "project"
 
-    # Create version as proper RFC 3339 timestamp with Z suffix (required by protobuf)
-    timestamp = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
-    # Convert +00:00 to Z (both are valid RFC 3339, but Z might be preferred)
-    version_str = timestamp.replace("+00:00", "Z")
-
     log_dir = os.path.join(root_dir, name)
     os.makedirs(log_dir, exist_ok=True)
 
     # Create experiment
     experiment = Experiment(
         name=name,
-        version=version_str,
         teamspace=teamspace,
         metadata=metadata or {},
         store_step=store_step,

--- a/src/litlogger/logger.py
+++ b/src/litlogger/logger.py
@@ -18,7 +18,7 @@ import os
 import warnings
 from argparse import Namespace
 from collections.abc import Mapping
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict
 
 from lightning_utilities import module_available
@@ -135,7 +135,6 @@ else:
             """
             self._root_dir = os.fspath(root_dir or "./lightning_logs")
             self._name = name or _create_name()
-            self._version = None
             self._teamspace = teamspace
             self._experiment: Experiment | None = None
             self._sub_dir = None
@@ -158,9 +157,8 @@ else:
 
         @property
         @override
-        def version(self) -> str:
-            """Get the experiment version - its time of creation."""
-            return self._version
+        def version(self) -> str | None:
+            return None
 
         @property
         @override
@@ -171,12 +169,7 @@ else:
         @property
         @override
         def log_dir(self) -> str:
-            """The directory for this run's tensorboard checkpoint.
-
-            By default, it is named ``'version_${self.version}'`` but it can be overridden by passing a string value
-            for the constructor's version parameter instead of ``None`` or an int.
-
-            """
+            """The directory for this run's tensorboard checkpoint."""
             log_dir = os.path.join(self.root_dir, self.name)
             if isinstance(self.sub_dir, str):
                 log_dir = os.path.join(log_dir, self.sub_dir)
@@ -206,15 +199,8 @@ else:
             if self.root_dir:
                 self._fs.makedirs(self.root_dir, exist_ok=True)
 
-            if self.version is None:
-                # Generate version as proper RFC 3339 timestamp with Z suffix (required by protobuf)
-                timestamp = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
-                # Convert +00:00 to Z (both are valid RFC 3339, but Z might be preferred)
-                self._version = timestamp.replace("+00:00", "Z")
-
             self._experiment = Experiment(
                 name=self._name,
-                version=self.version,
                 teamspace=self._teamspace,
                 metadata={k: str(v) for k, v in self._metadata.items()},
                 store_step=True,
@@ -308,7 +294,7 @@ else:
             Args:
                 path: Path to the local model file or directory to upload.
                 verbose: Whether to show progress bar during upload. Defaults to False.
-                version: Optional version string for the model. Defaults to the experiment version.
+                version: Optional version string for the model.
             """
             self._is_ready = True
             self._store_step = True

--- a/src/litlogger/printer.py
+++ b/src/litlogger/printer.py
@@ -271,7 +271,6 @@ class Printer:
         name: str,
         teamspace: str,
         url: str,
-        version: str | None = None,
         metadata: Dict[str, str] | None = None,
         show_logo: bool = True,
     ) -> None:
@@ -310,9 +309,6 @@ class Printer:
                 f"               Teamspace: {self.code(teamspace)}",
             ]
 
-            if version:
-                info_lines.append(f"                 Version: {self.secondary(version)}")
-
             if metadata:
                 items = list(metadata.items())[:3]
                 meta_str = ", ".join(f"{k}={v}" for k, v in items)
@@ -348,9 +344,6 @@ class Printer:
             self._echo(f"{rocket}{prefix_space}Experiment initialized")
             self._echo(f"           Name: {self.name(name)}", prefix=False)
             self._echo(f"      Teamspace: {self.code(teamspace)}", prefix=False)
-
-            if version:
-                self._echo(f"        Version: {self.secondary(version)}", prefix=False)
 
             if metadata:
                 items = list(metadata.items())[:3]

--- a/tests/integrations/test_standalone.py
+++ b/tests/integrations/test_standalone.py
@@ -586,11 +586,7 @@ def test_get_metadata_empty():
 @pytest.mark.cloud()
 def test_get_metadata_direct_experiment():
     """Test experiment.metadata property when using Experiment class directly."""
-    from datetime import datetime, timezone
-
     experiment_name = f"meta_direct-{uuid.uuid4().hex}"
-    timestamp = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
-    version_str = timestamp.replace("+00:00", "Z")
 
     metadata = {
         "framework": "PyTorch",
@@ -600,7 +596,6 @@ def test_get_metadata_direct_experiment():
     with tempfile.TemporaryDirectory() as tmpdir:
         exp = Experiment(
             name=experiment_name,
-            version=version_str,
             teamspace="oss-litlogger",
             log_dir=tmpdir,
             metadata=metadata,
@@ -663,17 +658,11 @@ def test_custom_colors():
 @pytest.mark.cloud()
 def test_direct_experiment_usage():
     """Test using the Experiment class directly without module-level API."""
-    from datetime import datetime, timezone
-
     experiment_name = f"standalone_direct_exp-{uuid.uuid4().hex}"
-    # Create version as proper RFC 3339 timestamp with Z suffix (required by protobuf)
-    timestamp = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
-    version_str = timestamp.replace("+00:00", "Z")
 
     with tempfile.TemporaryDirectory() as tmpdir:
         exp = Experiment(
             name=experiment_name,
-            version=version_str,
             teamspace="oss-litlogger",
             log_dir=tmpdir,
             metadata={"direct": "true"},
@@ -857,15 +846,10 @@ def test_get_or_create_experiment_metrics():
     api = MetricsApi()
     client = LitRestClient()
 
-    from datetime import datetime, timezone
-
-    version = datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
-
     # get_or_create should return the existing experiment (created by litlogger.init)
     experiment, created = api.get_or_create_experiment_metrics(
         teamspace_id=teamspace_id,
         name=experiment_name,
-        version=version,
     )
 
     assert created is False
@@ -885,7 +869,6 @@ def test_get_or_create_experiment_metrics():
     new_experiment, new_created = api.get_or_create_experiment_metrics(
         teamspace_id=teamspace_id,
         name=new_experiment_name,
-        version=version,
     )
 
     assert new_created is True

--- a/tests/unittests/api/test_metrics_api.py
+++ b/tests/unittests/api/test_metrics_api.py
@@ -48,54 +48,26 @@ class TestMetricsApi:
         assert result.id == "ms-123"
         assert result.name == "my-experiment"
 
-    def test_get_experiment_metrics_by_name_returns_latest_version(self):
-        """Test that get_experiment_metrics_by_name returns the latest version when multiple exist."""
+    def test_get_experiment_metrics_by_name_returns_first_match(self):
+        """Test that get_experiment_metrics_by_name returns the first match when multiple exist."""
         mock_client = MagicMock()
-        mock_stream_v1 = MagicMock()
-        mock_stream_v1.id = "ms-123"
-        mock_stream_v1.name = "my-experiment"
-        mock_stream_v1.version_number = 1
-        mock_stream_v2 = MagicMock()
-        mock_stream_v2.id = "ms-456"
-        mock_stream_v2.name = "my-experiment"
-        mock_stream_v2.version_number = 2
+        mock_stream_1 = MagicMock()
+        mock_stream_1.id = "ms-123"
+        mock_stream_1.name = "my-experiment"
+        mock_stream_2 = MagicMock()
+        mock_stream_2.id = "ms-456"
+        mock_stream_2.name = "my-experiment"
         mock_response = MagicMock()
-        mock_response.metrics_streams = [mock_stream_v1, mock_stream_v2]
+        mock_response.metrics_streams = [mock_stream_1, mock_stream_2]
         mock_client.lit_logger_service_list_metrics_streams.return_value = mock_response
         api = MetricsApi(client=mock_client)
 
         result = api.get_experiment_metrics_by_name(
             teamspace_id="ts-123",
             name="my-experiment",
-        )
-
-        assert result.id == "ms-456"
-        assert result.version_number == 2
-
-    def test_get_experiment_metrics_by_name_with_version(self):
-        """Test fetching a specific version of an experiment by name."""
-        mock_client = MagicMock()
-        mock_stream_v1 = MagicMock()
-        mock_stream_v1.id = "ms-123"
-        mock_stream_v1.name = "my-experiment"
-        mock_stream_v1.version_number = 1
-        mock_stream_v2 = MagicMock()
-        mock_stream_v2.id = "ms-456"
-        mock_stream_v2.name = "my-experiment"
-        mock_stream_v2.version_number = 2
-        mock_response = MagicMock()
-        mock_response.metrics_streams = [mock_stream_v1, mock_stream_v2]
-        mock_client.lit_logger_service_list_metrics_streams.return_value = mock_response
-        api = MetricsApi(client=mock_client)
-
-        result = api.get_experiment_metrics_by_name(
-            teamspace_id="ts-123",
-            name="my-experiment",
-            version_number=1,
         )
 
         assert result.id == "ms-123"
-        assert result.version_number == 1
 
     def test_get_experiment_metrics_by_name_not_found(self):
         """Test that get_experiment_metrics_by_name returns None when experiment not found."""
@@ -108,26 +80,6 @@ class TestMetricsApi:
         result = api.get_experiment_metrics_by_name(
             teamspace_id="ts-123",
             name="nonexistent",
-        )
-
-        assert result is None
-
-    def test_get_experiment_metrics_by_name_version_not_found(self):
-        """Test that get_experiment_metrics_by_name returns None when specific version not found."""
-        mock_client = MagicMock()
-        mock_stream = MagicMock()
-        mock_stream.id = "ms-123"
-        mock_stream.name = "my-experiment"
-        mock_stream.version_number = 1
-        mock_response = MagicMock()
-        mock_response.metrics_streams = [mock_stream]
-        mock_client.lit_logger_service_list_metrics_streams.return_value = mock_response
-        api = MetricsApi(client=mock_client)
-
-        result = api.get_experiment_metrics_by_name(
-            teamspace_id="ts-123",
-            name="my-experiment",
-            version_number=99,
         )
 
         assert result is None
@@ -153,7 +105,6 @@ class TestMetricsApi:
             result, created = api.get_or_create_experiment_metrics(
                 teamspace_id="ts-123",
                 name="my-experiment",
-                version="v1",
             )
 
         assert created is True
@@ -167,7 +118,6 @@ class TestMetricsApi:
         mock_existing = MagicMock()
         mock_existing.id = "ms-existing"
         mock_existing.name = "my-experiment"
-        mock_existing.version_number = 1
         mock_list_response = MagicMock()
         mock_list_response.metrics_streams = [mock_existing]
         mock_client.lit_logger_service_list_metrics_streams.return_value = mock_list_response
@@ -176,7 +126,6 @@ class TestMetricsApi:
         result, created = api.get_or_create_experiment_metrics(
             teamspace_id="ts-123",
             name="my-experiment",
-            version="v1",
         )
 
         assert created is False
@@ -207,11 +156,10 @@ class TestMetricsApi:
             api.create_experiment_metrics(
                 teamspace_id="ts-123",
                 name="my-experiment",
-                version="v1",
             )
 
-            # Verify _create_colors was called with name and version
-            mock_colors.assert_called_once_with("my-experiment", "v1")
+            # Verify _create_colors was called with name
+            mock_colors.assert_called_once_with("my-experiment")
 
             # Check that client method was called
             mock_client.lit_logger_service_create_metrics_stream.assert_called_once()
@@ -219,7 +167,6 @@ class TestMetricsApi:
 
             # Verify parameters
             assert call_args[1]["body"].name == "my-experiment"
-            assert call_args[1]["body"].version == "v1"
             assert call_args[1]["body"].store_step is True
             assert call_args[1]["body"].store_created_at is False
 
@@ -242,7 +189,6 @@ class TestMetricsApi:
             api.create_experiment_metrics(
                 teamspace_id="ts-123",
                 name="my-experiment",
-                version="v1",
                 metadata=metadata,
             )
 
@@ -267,7 +213,6 @@ class TestMetricsApi:
             api.create_experiment_metrics(
                 teamspace_id="ts-123",
                 name="my-experiment",
-                version="v1",
                 light_color="#custom-light",
                 dark_color="#custom-dark",
             )
@@ -292,7 +237,6 @@ class TestMetricsApi:
             api.create_experiment_metrics(
                 teamspace_id="ts-123",
                 name="my-experiment",
-                version="v1",
                 store_step=False,
                 store_created_at=True,
             )

--- a/tests/unittests/api/test_utils.py
+++ b/tests/unittests/api/test_utils.py
@@ -309,11 +309,10 @@ class TestBuildExperimentUrl:
                 owner_name="my-org",
                 teamspace_name="my-teamspace",
                 experiment_name="my-experiment",
-                version="1",
             )
 
             # The URL should be constructed from the parameters
-            assert url == "https://lightning.ai/my-org/my-teamspace/experiments/my-experiment%20-%20v1"
+            assert url == "https://lightning.ai/my-org/my-teamspace/experiments/my-experiment"
 
 
 class TestGetAccessibleUrl:

--- a/tests/unittests/test_background_thread.py
+++ b/tests/unittests/test_background_thread.py
@@ -37,7 +37,6 @@ class TestBackgroundThreadInit:
                 stop_event=stop_event,
                 done_event=done_event,
                 log_dir="/test/logs",
-                version="v1.0.0",
                 store_step=True,
                 store_created_at=False,
                 trackers_init=initial_trackers,
@@ -62,7 +61,6 @@ class TestBackgroundThreadInit:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
                 trackers_init=None,
@@ -89,7 +87,6 @@ class TestBackgroundThreadInit:
                 stop_event=stop_event,
                 done_event=done_event,
                 log_dir="/test/logs",
-                version="v1.0.0",
                 store_step=True,
                 store_created_at=False,
                 rate_limiting_interval=2,
@@ -115,7 +112,6 @@ class TestBackgroundThreadInit:
             # Verify BinaryFileWriter was initialized correctly
             mock_file_writer.assert_called_once_with(
                 log_dir="/test/logs",
-                version="v1.0.0",
                 store_step=True,
                 store_created_at=False,
                 teamspace_id="test_teamspace",
@@ -137,7 +133,6 @@ class TestBackgroundThreadInit:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -167,7 +162,6 @@ class TestBackgroundThreadStepBatching:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
                 rate_limiting_interval=100,  # High value to prevent time-based send
@@ -194,7 +188,6 @@ class TestBackgroundThreadStepBatching:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -224,7 +217,6 @@ class TestBackgroundThreadStepBatching:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
                 rate_limiting_interval=100,  # High value to prevent time-based send
@@ -255,7 +247,6 @@ class TestBackgroundThreadStepBatching:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
                 max_batch_size=50,  # Set low threshold
@@ -284,7 +275,6 @@ class TestBackgroundThreadStepBatching:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
                 rate_limiting_interval=100,  # High value to prevent time-based send
@@ -315,7 +305,6 @@ class TestBackgroundThreadStepAugmentation:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -350,7 +339,6 @@ class TestBackgroundThreadStepAugmentation:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -389,7 +377,6 @@ class TestBackgroundThreadStepAugmentation:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
                 trackers_init=initial_trackers,
@@ -423,7 +410,6 @@ class TestBackgroundThreadStepAugmentation:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -462,7 +448,6 @@ class TestBackgroundThreadUpdateTracker:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -489,7 +474,6 @@ class TestBackgroundThreadUpdateTracker:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -519,7 +503,6 @@ class TestBackgroundThreadUpdateTracker:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -555,7 +538,6 @@ class TestBackgroundThreadUpdateTracker:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="test",
-                version="test",
                 store_step=True,
                 store_created_at=False,
             )
@@ -598,7 +580,6 @@ class TestBackgroundThreadUpdateTracker:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=True,
             )
@@ -638,7 +619,6 @@ class TestBackgroundThreadSend:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -665,7 +645,6 @@ class TestBackgroundThreadSend:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -700,7 +679,6 @@ class TestBackgroundThreadSend:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -730,7 +708,6 @@ class TestBackgroundThreadSend:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -760,7 +737,6 @@ class TestBackgroundThreadSendMetrics:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -786,7 +762,6 @@ class TestBackgroundThreadSendMetrics:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -812,7 +787,6 @@ class TestBackgroundThreadSendMetrics:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
                 max_batch_size=1000,
@@ -840,7 +814,6 @@ class TestBackgroundThreadSendMetrics:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
                 max_batch_size=100,
@@ -872,7 +845,6 @@ class TestBackgroundThreadSendMetrics:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
                 max_batch_size=50,
@@ -906,7 +878,6 @@ class TestBackgroundThreadStep:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
                 rate_limiting_interval=100,  # Prevent time-based send
@@ -932,7 +903,6 @@ class TestBackgroundThreadStep:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -960,7 +930,6 @@ class TestBackgroundThreadInformDone:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -998,7 +967,6 @@ class TestBackgroundThreadInformDone:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=True,
             )
@@ -1046,7 +1014,6 @@ class TestBackgroundThreadRun:
                 stop_event=Event(),
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -1073,7 +1040,6 @@ class TestBackgroundThreadRun:
                 stop_event=stop_event,
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -1111,7 +1077,6 @@ class TestBackgroundThreadRun:
                 stop_event=stop_event,
                 done_event=Event(),
                 log_dir="/test",
-                version="v1",
                 store_step=True,
                 store_created_at=False,
             )
@@ -1157,7 +1122,6 @@ class TestBackgroundThreadIntegration:
                 stop_event=stop_event,
                 done_event=done_event,
                 log_dir="/test",
-                version="v1.0.0",
                 store_step=True,
                 store_created_at=False,
             )

--- a/tests/unittests/test_colors.py
+++ b/tests/unittests/test_colors.py
@@ -10,45 +10,34 @@ from litlogger.colors import _create_colors
 class TestCreateColors:
     """Test the _create_colors function."""
 
-    def test_same_name_different_version_different_colors(self):
-        """Test that same name with different versions get different colors."""
-        color1 = _create_colors("my-experiment", "v1")
-        color2 = _create_colors("my-experiment", "v2")
-        color3 = _create_colors("my-experiment", "v3")
+    def test_different_names_different_colors(self):
+        """Test that different experiment names get different colors."""
+        color1 = _create_colors("experiment-a")
+        color2 = _create_colors("experiment-b")
 
-        # All should be different
+        # Should be different (with high probability due to hash)
         assert color1 != color2
-        assert color2 != color3
-        assert color1 != color3
 
     def test_deterministic_colors(self):
-        """Test that same name+version always returns same colors."""
-        color1 = _create_colors("my-experiment", "v1")
-        color2 = _create_colors("my-experiment", "v1")
+        """Test that same name always returns same colors."""
+        color1 = _create_colors("my-experiment")
+        color2 = _create_colors("my-experiment")
 
         assert color1 == color2
 
     def test_returns_tuple_of_two_colors(self):
         """Test that function returns a tuple of (light_color, dark_color)."""
-        result = _create_colors("test", "v1")
+        result = _create_colors("test")
 
         assert isinstance(result, tuple)
         assert len(result) == 2
         assert result[0].startswith("#")
         assert result[1].startswith("#")
 
-    def test_different_names_different_colors(self):
-        """Test that different experiment names get different colors."""
-        color1 = _create_colors("experiment-a", "v1")
-        color2 = _create_colors("experiment-b", "v1")
-
-        # Should be different (with high probability due to hash)
-        assert color1 != color2
-
-    def test_fallback_to_random_without_name_version(self):
-        """Test that without name/version, colors are still returned."""
+    def test_fallback_to_random_without_name(self):
+        """Test that without name, colors are still returned."""
         color1 = _create_colors()
-        color2 = _create_colors(None, None)
+        color2 = _create_colors(None)
 
         # Should return valid colors (may or may not be same due to random)
         assert isinstance(color1, tuple)

--- a/tests/unittests/test_experiment.py
+++ b/tests/unittests/test_experiment.py
@@ -58,7 +58,6 @@ def test_experiment_sender_queue(tmpdir):
         stop_event=stop_event,
         done_event=done_event,
         log_dir=str(tmpdir),
-        version="fake_timestamp",
         store_step=False,
         store_created_at=False,
     )
@@ -226,7 +225,6 @@ class TestExperimentArtifactMethods:
 
         exp = MagicMock()
         exp.name = "test_exp"
-        exp.version = "v1.0"
         exp._teamspace = MagicMock()
 
         # Call the actual method implementation
@@ -250,7 +248,6 @@ class TestExperimentArtifactMethods:
 
         exp = MagicMock()
         exp.name = "test_exp"
-        exp.version = "v1.0"
         exp._teamspace = MagicMock()
 
         # Call the actual method implementation
@@ -260,7 +257,7 @@ class TestExperimentArtifactMethods:
 
         # Verify ModelArtifact was created correctly
         mock_model_artifact_class.assert_called_once_with(
-            path="model.pt", experiment_name="test_exp", teamspace=exp._teamspace, version="v1.0", verbose=False
+            path="model.pt", experiment_name="test_exp", teamspace=exp._teamspace, version="latest", verbose=False
         )
         # Verify get was called and result returned
         mock_model_artifact.get.assert_called_once()
@@ -274,7 +271,6 @@ class TestExperimentArtifactMethods:
 
         exp = MagicMock()
         exp.name = "test_exp"
-        exp.version = "v1.0"
         exp._teamspace = MagicMock()
 
         mock_model_obj = MagicMock()
@@ -289,7 +285,7 @@ class TestExperimentArtifactMethods:
             model=mock_model_obj,
             experiment_name="test_exp",
             teamspace=exp._teamspace,
-            version="v1.0",
+            version="latest",
             verbose=False,
             metadata={"key": "value"},
             staging_dir="/tmp/staging",
@@ -307,7 +303,6 @@ class TestExperimentArtifactMethods:
 
         exp = MagicMock()
         exp.name = "test_exp"
-        exp.version = "v1.0"
         exp._teamspace = MagicMock()
 
         # Call the actual method implementation
@@ -320,7 +315,7 @@ class TestExperimentArtifactMethods:
             model=None,
             experiment_name="test_exp",
             teamspace=exp._teamspace,
-            version="v1.0",
+            version="latest",
             verbose=False,
             staging_dir="/tmp/staging",
         )

--- a/tests/unittests/test_file_writer.py
+++ b/tests/unittests/test_file_writer.py
@@ -11,7 +11,6 @@ def test_file_writer(tmpdir):
 
     store = BinaryFileWriter(
         log_dir=str(tmpdir),
-        version="fake_timestamp",
         store_step=False,
         store_created_at=False,
         teamspace_id="project_id",

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -166,7 +166,6 @@ class TestInit:
 
         call_kwargs = mock_experiment_class.call_args.kwargs
         assert call_kwargs["name"] == "test"
-        assert "version" in call_kwargs
         assert call_kwargs["teamspace"] is None
 
     @patch.object(init_module, "Experiment")
@@ -184,7 +183,6 @@ class TestInit:
 
         call_kwargs = mock_experiment_class.call_args.kwargs
         assert call_kwargs["name"] == "test"
-        assert "version" in call_kwargs
         assert call_kwargs["teamspace"] is None
 
     @patch.object(init_module, "Experiment")
@@ -202,7 +200,6 @@ class TestInit:
 
         call_kwargs = mock_experiment_class.call_args.kwargs
         assert call_kwargs["name"] == "test"
-        assert "version" in call_kwargs
         assert call_kwargs["teamspace"] is None
 
     @patch.object(init_module, "Experiment")
@@ -224,22 +221,6 @@ class TestInit:
         actual_path = call_args[0][0].replace("\\", "/")
         assert "/tmp/logs/test-exp" in actual_path
         assert call_args[1]["exist_ok"] is True
-
-    @patch.object(init_module, "Experiment")
-    @patch.object(init_module, "set_global")
-    @patch("subprocess.check_output")
-    def test_init_version_is_created(self, mock_check_output, mock_set_global, mock_experiment_class):
-        """Test that a version string is created."""
-        mock_check_output.return_value = b"/path/to/repo\n"
-        mock_experiment = MagicMock()
-        mock_experiment_class.return_value = mock_experiment
-
-        init(name="test")
-
-        call_kwargs = mock_experiment_class.call_args.kwargs
-        # Version should be a string (timestamp in ISO format)
-        assert isinstance(call_kwargs["version"], str | dict)
-        assert "version" in call_kwargs
 
 
 class TestFinish:

--- a/tests/unittests/test_logger.py
+++ b/tests/unittests/test_logger.py
@@ -27,15 +27,6 @@ def test_logger_name_property():
     assert logger._name == "test_logger"
 
 
-def test_logger_version_property():
-    """Test that logger has a version property."""
-    # Mock the logger to avoid actual initialization
-    logger = object.__new__(LightningLogger)
-    logger._version = "v1.0"
-
-    assert logger._version == "v1.0"
-
-
 def test_log_file():
     """Test that LightningLogger has a log_file method."""
     from litlogger import LightningLogger


### PR DESCRIPTION
Removes experiment versioning to streamline UX for resuming.

In the past the versioning was only appending to a name which can also be done manually still.
Providing the same experiment name resumes the experiment now rather than creating a new version of it.