### PR TITLE
Ignore uv.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,6 @@ cython_debug/
 # our binary format
 *.tar.gz
 *.litbin
+
+# since this is a library, we don't want to lock uv versions
+uv.lock


### PR DESCRIPTION
This is a library supposed to work in many environments. Therefore we want to narrow down the version requirements just as much as we need to, but not pin them any more.