### PR TITLE
Add actual content for documentation

### DIFF
--- a/docs/source/api/module_api.rst
+++ b/docs/source/api/module_api.rst
@@ -10,13 +10,10 @@ Initialization
 .. currentmodule:: litlogger.init
 
 .. autofunction:: init
-    :no-index:
 
 .. autofunction:: finish
-    :no-index:
 
 .. autofunction:: get_metadata
-    :no-index:
 
 Experiment Methods
 ------------------

--- a/docs/source/guide/artifacts.rst
+++ b/docs/source/guide/artifacts.rst
@@ -2,4 +2,93 @@
 Logging Artifacts
 #################
 
-.. todo:: Add guide for logging files, models, and checkpoints.
+LitLogger can store and retrieve files and model artifacts associated with
+your experiments.
+
+
+Log and Retrieve Files
+======================
+
+.. code-block:: python
+
+   import litlogger
+
+   # Log files
+   litlogger.init(name="my-experiment")
+   litlogger.log_file("config.yaml")
+   litlogger.log_file("checkpoint.pt", remote_path="checkpoints/best.pt")
+   litlogger.finalize()
+
+   # Retrieve files later
+   litlogger.init(name="my-experiment")
+   litlogger.get_file("/tmp/config.yaml", remote_path="config.yaml")
+   litlogger.get_file("/tmp/best.pt", remote_path="checkpoints/best.pt")
+   litlogger.finalize()
+
+
+Logging Multiple Files
+======================
+
+``log_files`` uploads a list of files in parallel for better throughput:
+
+.. code-block:: python
+
+   exp = litlogger.init(name="my-experiment")
+   exp.log_files(
+       paths=["img_0.png", "img_1.png", "img_2.png"],
+       remote_paths=["images/0.png", "images/1.png", "images/2.png"],
+   )
+
+
+Log and Retrieve Models
+=======================
+
+LitLogger integrates with ``litmodels`` for storing and loading model objects:
+
+.. code-block:: python
+
+   import torch.nn as nn
+   import litlogger
+
+   # Log a model
+   litlogger.init(name="my-experiment")
+   model = nn.Linear(10, 1)
+   litlogger.log_model(model)
+   litlogger.finalize()
+
+   # Retrieve the model later
+   litlogger.init(name="my-experiment")
+   loaded_model = litlogger.get_model()
+   litlogger.finalize()
+
+
+Logging Model Files
+===================
+
+If you already have saved model files on disk (weights, checkpoints, or full
+directories), use ``log_model_artifact``:
+
+.. code-block:: python
+
+   exp = litlogger.init(name="my-experiment")
+
+   # Upload a single checkpoint file
+   exp.log_model_artifact("checkpoints/epoch_10.ckpt", version="epoch-10")
+
+   # Upload an entire directory
+   exp.log_model_artifact("model_export/", version="export-v2")
+
+Download model artifacts back:
+
+.. code-block:: python
+
+   exp.get_model_artifact("local_checkpoint.ckpt", version="epoch-10")
+
+
+Automatic Checkpoint Logging
+=============================
+
+When using :class:`~litlogger.logger.LightningLogger` with
+``log_model=True``, checkpoints saved by Lightning's ``ModelCheckpoint``
+callback are automatically uploaded as model artifacts. See
+:doc:`lightning` for details.

--- a/docs/source/guide/artifacts.rst
+++ b/docs/source/guide/artifacts.rst
@@ -29,7 +29,8 @@ Log and Retrieve Files
 Logging Multiple Files
 ======================
 
-``log_files`` uploads a list of files in parallel for better throughput:
+:meth:`litlogger.log_files() <litlogger.experiment.Experiment.log_files>` uploads
+a list of files in parallel for better throughput:
 
 .. code-block:: python
 
@@ -66,7 +67,7 @@ Logging Model Files
 ===================
 
 If you already have saved model files on disk (weights, checkpoints, or full
-directories), use ``log_model_artifact``:
+directories), use :meth:`litlogger.log_model_artifact() <litlogger.experiment.Experiment.log_model_artifact>`:
 
 .. code-block:: python
 

--- a/docs/source/guide/examples.rst
+++ b/docs/source/guide/examples.rst
@@ -1,0 +1,61 @@
+########
+Examples
+########
+
+
+Standalone
+==========
+
+A standalone training script using the module-level API to log metrics,
+metadata, and files.
+
+.. literalinclude:: ../../../examples/standalone_usage.py
+   :language: python
+   :start-after: limitations under the License.
+
+
+PyTorch Lightning
+=================
+
+An MNIST autoencoder trained with PyTorch Lightning and ``LightningLogger``.
+
+.. literalinclude:: ../../../examples/lightning_autoencoder.py
+   :language: python
+   :start-after: limitations under the License.
+
+
+LitServe
+========
+
+Track inference metrics from a LitServe endpoint. Requires ``pip install litgpt``.
+
+.. literalinclude:: ../../../examples/litserve_inference.py
+   :language: python
+   :start-after: limitations under the License.
+
+Run with ``python litserve_inference.py``, then test with:
+
+.. code-block:: bash
+
+   curl -X POST http://127.0.0.1:8000/predict \
+     -H "Content-Type: application/json" \
+     -d '{"prompt": "What do llamas eat"}'
+
+
+Complete Workflow
+=================
+
+A complete workflow demonstrating logging and retrieval of metrics, metadata,
+and files.
+
+**train.py** -- Log experiment:
+
+.. literalinclude:: ../../../examples/complete_workflow/train.py
+   :language: python
+   :start-after: limitations under the License.
+
+**fetch.py** -- Get experiment data:
+
+.. literalinclude:: ../../../examples/complete_workflow/fetch.py
+   :language: python
+   :start-after: limitations under the License.

--- a/docs/source/guide/lightning.rst
+++ b/docs/source/guide/lightning.rst
@@ -2,4 +2,122 @@
 Lightning Integration
 #######################
 
-.. todo:: Add guide for using litlogger with PyTorch Lightning Trainer and Fabric.
+:class:`~litlogger.logger.LightningLogger` plugs directly into the PyTorch
+Lightning ``Trainer`` and Lightning Fabric, streaming metrics and artifacts to
+`lightning.ai <https://lightning.ai>`_.
+
+
+Using with Trainer
+==================
+
+Pass a ``LightningLogger`` as the ``logger`` argument to the Trainer.
+Every ``self.log()`` call inside your LightningModule is automatically
+forwarded to Lightning.ai:
+
+.. code-block:: python
+
+   from lightning import Trainer
+   from litlogger import LightningLogger
+
+   logger = LightningLogger(name="cifar10-resnet")
+   trainer = Trainer(max_epochs=10, logger=logger)
+   trainer.fit(model, datamodule)
+
+After ``trainer.fit()`` starts, the logger prints a URL where you can view
+live training curves.
+
+
+Logging Hyperparameters
+=======================
+
+Lightning automatically calls ``log_hyperparams`` when your LightningModule
+defines ``self.save_hyperparameters()``. The hyperparameters appear as tags in
+the experiment UI:
+
+.. code-block:: python
+
+   class MyModel(L.LightningModule):
+       def __init__(self, lr: float = 1e-3, hidden_dim: int = 128):
+           super().__init__()
+           self.save_hyperparameters()
+
+You can also pass metadata directly:
+
+.. code-block:: python
+
+   logger = LightningLogger(
+       name="cifar10-resnet",
+       metadata={"optimizer": "AdamW", "scheduler": "cosine"},
+   )
+
+
+Automatic Checkpoint Logging
+=============================
+
+Set ``log_model=True`` to automatically upload checkpoints to the litmodels
+registry whenever Lightning saves a checkpoint:
+
+.. code-block:: python
+
+   from lightning.pytorch.callbacks import ModelCheckpoint
+
+   checkpoint_cb = ModelCheckpoint(save_top_k=2, monitor="val_loss")
+   logger = LightningLogger(name="my-model", log_model=True)
+
+   trainer = Trainer(
+       max_epochs=20,
+       logger=logger,
+       callbacks=[checkpoint_cb],
+   )
+   trainer.fit(model, datamodule)
+
+
+Using with Fabric
+=================
+
+``LightningLogger`` also works as a Fabric logger:
+
+.. code-block:: python
+
+   import lightning as L
+   from litlogger import LightningLogger
+
+   logger = LightningLogger(name="fabric-run")
+   fabric = L.Fabric(loggers=[logger])
+   fabric.launch()
+
+   for step in range(1000):
+       loss = train_step()
+       fabric.log("train_loss", loss, step=step)
+
+
+Logging Files and Media
+========================
+
+The logger exposes ``log_file`` and ``log_media`` for uploading artifacts
+during training:
+
+.. code-block:: python
+
+   # Inside a training callback or LightningModule
+   trainer.logger.log_file("config.yaml")
+   trainer.logger.log_media("sample", "output.png", step=epoch)
+
+
+Accessing the Experiment URL
+============================
+
+.. code-block:: python
+
+   logger = LightningLogger(name="my-run")
+   trainer = Trainer(logger=logger)
+   trainer.fit(model, datamodule)
+
+   print(logger.url)  # direct link to the experiment
+
+
+Third-Party Loggers
+===================
+
+Use any third-party logger you want with Lightning. However, LitLogger is free
+and native to the Lightning platform.

--- a/docs/source/guide/lightning.rst
+++ b/docs/source/guide/lightning.rst
@@ -10,7 +10,7 @@ Lightning ``Trainer`` and Lightning Fabric, streaming metrics and artifacts to
 Using with Trainer
 ==================
 
-Pass a ``LightningLogger`` as the ``logger`` argument to the Trainer.
+Pass a :class:`~litlogger.logger.LightningLogger` as the ``logger`` argument to the Trainer.
 Every ``self.log()`` call inside your LightningModule is automatically
 forwarded to Lightning.ai:
 
@@ -75,7 +75,7 @@ registry whenever Lightning saves a checkpoint:
 Using with Fabric
 =================
 
-``LightningLogger`` also works as a Fabric logger:
+:class:`~litlogger.logger.LightningLogger` also works as a Fabric logger:
 
 .. code-block:: python
 
@@ -94,7 +94,7 @@ Using with Fabric
 Logging Files and Media
 ========================
 
-The logger exposes ``log_file`` and ``log_media`` for uploading artifacts
+The logger exposes :meth:`litlogger.log_file() <litlogger.experiment.Experiment.log_file>` and :meth:`litlogger.log_media() <litlogger.experiment.Experiment.log_media>` for uploading artifacts
 during training:
 
 .. code-block:: python

--- a/docs/source/guide/media.rst
+++ b/docs/source/guide/media.rst
@@ -2,4 +2,91 @@
 Logging Media
 #############
 
-.. todo:: Add guide for logging images and text media.
+litlogger supports uploading images and text files that are displayed alongside
+your metrics in the `lightning.ai <https://lightning.ai>`_ experiment view.
+
+
+Logging Images
+==============
+
+.. code-block:: python
+
+   import litlogger
+   from litlogger.types import MediaType
+
+   exp = litlogger.init(name="my-experiment")
+
+   # Auto-detected from file extension
+   exp.log_media("sample_output", "generated.png", step=0)
+
+   # Explicit type
+   exp.log_media(
+       name="reconstruction",
+       path="recon.jpg",
+       kind=MediaType.IMAGE,
+       step=10,
+       caption="Epoch 10 reconstruction",
+   )
+
+
+Logging Text
+============
+
+.. code-block:: python
+
+   exp.log_media("predictions", "predictions.txt", kind=MediaType.TEXT, step=5)
+
+
+Supported Types
+===============
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - MediaType
+     - File extensions
+     - Description
+   * - ``IMAGE``
+     - ``.png``, ``.jpg``, ``.jpeg``, ``.gif``, ``.bmp``, ``.webp``
+     - Displayed as images in the experiment view
+   * - ``TEXT``
+     - ``.txt``, ``.csv``, ``.json``, ``.log``
+     - Displayed as text in the experiment view
+
+When ``kind`` is not provided, litlogger guesses the type from the file's MIME
+type. If the type cannot be determined, a ``ValueError`` is raised.
+
+
+Parameters
+==========
+
+``log_media`` accepts the following parameters:
+
+- **name** -- Name of the media entry.
+- **path** -- Local path to the file.
+- **kind** -- ``MediaType.IMAGE`` or ``MediaType.TEXT`` (optional, auto-detected).
+- **step** -- Training step number (optional).
+- **epoch** -- Training epoch number (optional).
+- **caption** -- Descriptive caption (optional).
+
+
+Using with LightningLogger
+===========================
+
+The :class:`~litlogger.logger.LightningLogger` exposes the same ``log_media``
+method, which you can call from callbacks or your LightningModule:
+
+.. code-block:: python
+
+   from litlogger import LightningLogger
+
+   logger = LightningLogger(name="vision-run")
+
+   # Inside a callback
+   logger.log_media(
+       "val_sample",
+       "val_output.png",
+       step=trainer.global_step,
+       caption="Validation sample",
+   )

--- a/docs/source/guide/media.rst
+++ b/docs/source/guide/media.rst
@@ -61,7 +61,8 @@ type. If the type cannot be determined, a ``ValueError`` is raised.
 Parameters
 ==========
 
-``log_media`` accepts the following parameters:
+:meth:`litlogger.log_media() <litlogger.experiment.Experiment.log_media>` accepts
+the following parameters:
 
 - **name** -- Name of the media entry.
 - **path** -- Local path to the file.
@@ -74,8 +75,8 @@ Parameters
 Using with LightningLogger
 ===========================
 
-The :class:`~litlogger.logger.LightningLogger` exposes the same ``log_media``
-method, which you can call from callbacks or your LightningModule:
+The :class:`~litlogger.logger.LightningLogger` exposes the same
+:meth:`litlogger.log_media() <litlogger.experiment.Experiment.log_media>` method, which you can call from callbacks or your LightningModule:
 
 .. code-block:: python
 

--- a/docs/source/guide/standalone.rst
+++ b/docs/source/guide/standalone.rst
@@ -22,16 +22,17 @@ Initialize an experiment, log metrics in a loop, and finalize when done:
 
    litlogger.finalize()
 
-After calling ``init()``, a URL is printed where you can view live charts on
-`lightning.ai <https://lightning.ai>`_.
+After calling :func:`litlogger.init() <litlogger.init.init>`, a URL is printed
+where you can view live charts on `lightning.ai <https://lightning.ai>`_.
 
 
 Tracking Metrics
 ================
 
-Use ``litlogger.log()`` (or equivalently ``litlogger.log_metrics()``) to send
-metric values. Metrics are buffered and uploaded in the background so your
-training loop is never blocked.
+Use :meth:`litlogger.log() <litlogger.experiment.Experiment.log_metrics>`
+(or equivalently :meth:`litlogger.log_metrics() <litlogger.experiment.Experiment.log_metrics>`)
+to send metric values. Metrics are buffered and uploaded in the background so
+your training loop is never blocked.
 
 .. code-block:: python
 
@@ -52,7 +53,7 @@ Metadata lets you tag experiments with key-value pairs like hyperparameters,
 model names, or dataset versions. This makes it easy to filter, compare, and
 identify experiments.
 
-Pass a ``metadata`` dictionary to ``init()``:
+Pass a ``metadata`` dictionary to :func:`litlogger.init() <litlogger.init.init>`:
 
 .. code-block:: python
 
@@ -70,8 +71,9 @@ Pass a ``metadata`` dictionary to ``init()``:
 Retrieve Metadata
 -----------------
 
-Retrieve metadata from any experiment using ``litlogger.get_metadata()`` or
-the ``experiment.metadata`` property:
+Retrieve metadata from any experiment using
+:func:`litlogger.get_metadata() <litlogger.init.get_metadata>` or the
+:attr:`Experiment.metadata <litlogger.experiment.Experiment.metadata>` property:
 
 .. code-block:: python
 
@@ -149,22 +151,21 @@ into a different one:
 Finalizing
 ==========
 
-``litlogger.finalize()`` flushes all remaining metrics to the cloud. It is
-called automatically via an ``atexit`` handler, but calling it explicitly
-guarantees that everything is uploaded before the process exits:
+:meth:`litlogger.finalize() <litlogger.experiment.Experiment.finalize>` flushes
+all remaining metrics to the cloud. It is called automatically via an
+``atexit`` handler, but calling it explicitly guarantees that everything is
+uploaded before the process exits:
 
 .. code-block:: python
 
    litlogger.finalize()
-   # or equivalently:
-   litlogger.finish()
 
 
 Using the Experiment Object
 ===========================
 
-``litlogger.init()`` returns an :class:`~litlogger.experiment.Experiment`
-instance that you can use directly:
+:func:`litlogger.init() <litlogger.init.init>` returns an
+:class:`~litlogger.experiment.Experiment` instance that you can use directly:
 
 .. code-block:: python
 

--- a/docs/source/guide/standalone.rst
+++ b/docs/source/guide/standalone.rst
@@ -2,4 +2,179 @@
 Standalone Usage
 ################
 
-.. todo:: Add guide for standalone usage.
+Use litlogger as a standalone experiment tracker in any Python script -- no
+framework required.
+
+Quick Start
+===========
+
+Initialize an experiment, log metrics in a loop, and finalize when done:
+
+.. code-block:: python
+
+   import litlogger
+
+   litlogger.init(name="my-experiment")
+
+   for step in range(100):
+       loss = 1.0 / (step + 1)
+       litlogger.log({"loss": loss, "accuracy": step / 100.0}, step=step)
+
+   litlogger.finalize()
+
+After calling ``init()``, a URL is printed where you can view live charts on
+`lightning.ai <https://lightning.ai>`_.
+
+
+Tracking Metrics
+================
+
+Use ``litlogger.log()`` (or equivalently ``litlogger.log_metrics()``) to send
+metric values. Metrics are buffered and uploaded in the background so your
+training loop is never blocked.
+
+.. code-block:: python
+
+   # Dictionary style
+   litlogger.log({"train/loss": 0.25, "train/acc": 0.91}, step=10)
+
+   # Keyword style
+   litlogger.log({}, step=10, val_loss=0.30, val_acc=0.88)
+
+
+Metadata
+========
+
+Log Metadata
+------------
+
+Metadata lets you tag experiments with key-value pairs like hyperparameters,
+model names, or dataset versions. This makes it easy to filter, compare, and
+identify experiments.
+
+Pass a ``metadata`` dictionary to ``init()``:
+
+.. code-block:: python
+
+   import litlogger
+
+   litlogger.init(
+       name="training-run",
+       metadata={
+           "model": "GPT-2",
+           "dataset": "WikiText",
+           "learning_rate": "0.0001",
+       },
+   )
+
+Retrieve Metadata
+-----------------
+
+Retrieve metadata from any experiment using ``litlogger.get_metadata()`` or
+the ``experiment.metadata`` property:
+
+.. code-block:: python
+
+   import litlogger
+
+   litlogger.init(name="training-run")
+
+   # Get metadata using the global function
+   metadata = litlogger.get_metadata()
+   print(metadata)  # {"model": "GPT-2", "dataset": "WikiText", ...}
+
+   # Or access via the experiment object
+   print(litlogger.experiment.metadata)
+
+
+Resume Experiments
+==================
+
+LitLogger automatically resumes experiments when you initialize with the same
+name. This is useful for continuing interrupted training or adding more data.
+
+.. code-block:: python
+
+   import litlogger
+
+   # First run - creates new experiment
+   litlogger.init(name="my-experiment")
+   for i in range(10):
+       litlogger.log_metrics({"loss": 1.0 / (i + 1)}, step=i)
+   litlogger.finalize()
+
+   # Later run - resumes the same experiment
+   litlogger.init(name="my-experiment")
+   for i in range(10, 20):
+       litlogger.log_metrics({"loss": 1.0 / (i + 1)}, step=i)
+   litlogger.finalize()
+
+
+Custom Chart Colors
+===================
+
+Override the default random colors with hex values:
+
+.. code-block:: python
+
+   exp = litlogger.init(
+       name="my-experiment",
+       light_color="#FF5733",
+       dark_color="#3498DB",
+   )
+
+
+Terminal Log Capture
+====================
+
+Set ``save_logs=True`` to capture your script's terminal output and upload it
+as a file artifact (``console_output.txt``):
+
+.. code-block:: python
+
+   litlogger.init(name="my-experiment", save_logs=True)
+
+
+Selecting a Teamspace
+======================
+
+By default litlogger uses your default teamspace. Pass a name explicitly to log
+into a different one:
+
+.. code-block:: python
+
+   litlogger.init(name="my-experiment", teamspace="research-team")
+
+
+Finalizing
+==========
+
+``litlogger.finalize()`` flushes all remaining metrics to the cloud. It is
+called automatically via an ``atexit`` handler, but calling it explicitly
+guarantees that everything is uploaded before the process exits:
+
+.. code-block:: python
+
+   litlogger.finalize()
+   # or equivalently:
+   litlogger.finish()
+
+
+Using the Experiment Object
+===========================
+
+``litlogger.init()`` returns an :class:`~litlogger.experiment.Experiment`
+instance that you can use directly:
+
+.. code-block:: python
+
+   exp = litlogger.init(name="my-experiment")
+
+   exp.log_metrics({"loss": 0.5}, step=0)
+   exp.log_file("config.yaml")
+   exp.log_model(model)
+
+   print(exp.url)       # direct link to the experiment
+   print(exp.metadata)  # metadata dict
+
+   exp.finalize()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,6 +43,8 @@ Install
 
    pip install litlogger
 
+See more details at :doc:`install`
+
 Hello World
 -----------
 
@@ -70,8 +72,8 @@ LitLogger provides two APIs: a **standalone API** for any Python code, and an
 Standalone API
 --------------
 
-The standalone API uses ``litlogger.init()`` and module-level functions. This
-is the recommended approach for most use cases.
+The standalone API uses :func:`litlogger.init() <litlogger.init.init>` and
+module-level functions. This is the recommended approach for most use cases.
 
 .. code-block:: python
 
@@ -92,9 +94,9 @@ See :doc:`guide/standalone` for the full guide.
 Experiment
 ----------
 
-``litlogger.init()`` returns an :class:`~litlogger.experiment.Experiment`
-instance. You can also create one directly for full control over the
-experiment lifecycle.
+:func:`litlogger.init() <litlogger.init.init>` returns an
+:class:`~litlogger.experiment.Experiment` instance. You can also create one
+directly for full control over the experiment lifecycle.
 
 .. code-block:: python
 
@@ -119,9 +121,9 @@ See the :doc:`api/experiment` reference for all available methods.
 PyTorch Lightning Integration
 =============================
 
-The ``LightningLogger`` class integrates directly with the PyTorch Lightning
-Trainer, so every ``self.log()`` call is automatically forwarded to
-Lightning.ai.
+The :class:`~litlogger.logger.LightningLogger` class integrates directly with
+the PyTorch Lightning Trainer, so every ``self.log()`` call is automatically
+forwarded to Lightning.ai.
 
 .. code-block:: python
 
@@ -152,14 +154,6 @@ Open an experiment detail to share with everyone or specific users.
 
 .. image:: https://storage.googleapis.com/lightning-avatars/litpages/01j07an7zgc2ewmnnxj8gngg72/19d278b1-32a4-43ac-9a03-200aa0687e69.png
    :alt: Sharing option for experiments
-
-----
-
-Third-Party Loggers
-===================
-
-Use any third-party logger you want with Lightning. However, LitLogger is free
-and native to the Lightning platform.
 
 ----
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -183,6 +183,7 @@ and native to the Lightning platform.
     guide/lightning
     guide/artifacts
     guide/media
+    guide/examples
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -183,7 +183,6 @@ and native to the Lightning platform.
     guide/lightning
     guide/artifacts
     guide/media
-    guide/examples
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,52 +1,167 @@
-##########################
-Welcome to litlogger
-##########################
+######################
+Experiment Management
+######################
 
-.. raw:: html
+Lightning AI comes with a free, bundled experiment manager called LitLogger.
+Experiment managers let you track, compare and share ML model training runs.
+It keeps them organized and reproducible, providing clear visibility into model
+performance.
 
-   <p style="font-size: 18px">
-      Track machine learning experiments with <a href="https://lightning.ai">Lightning.ai</a>.
-      Log metrics, hyperparameters, checkpoints, and artifacts from any training script.
-   </p>
+.. image:: https://storage.googleapis.com/lightning-avatars/litpages/01jrbsmwcrgj50pbybv827wc5d/9ee96e2e-58bd-4031-991f-1cff59009d19.png
+   :alt: LitLogger experiment dashboard
 
-.. raw:: html
+----
 
-   <hr class="docutils" style="margin: 50px 0 50px 0">
+Why LitLogger
+=============
 
+Without reliable experiment management, teams lose history, cannot compare
+experiments, and struggle to reproduce or audit their work. LitLogger solves
+this with a built-in, persistent experiment manager that automatically
+organizes every run -- centralizing metrics, metadata, and artifacts so
+experiments can be compared, restored, and shared easily. The result is
+clarity of research results, faster iteration, and reproducible model
+development without having to pay for a standalone platform.
 
-Install litlogger
------------------
+Key features:
+
+- Generous free tier
+- PyTorch optimized
+- Share with anyone
+- Granular permissions (RBAC)
+- Granular project management
+
+----
+
+Quick Start
+===========
+
+Install
+-------
 
 .. code-block:: bash
 
-    pip install litlogger
+   pip install litlogger
 
-
-.. raw:: html
-
-   <hr class="docutils" style="margin: 50px 0 50px 0">
-
-
-Get Started
+Hello World
 -----------
 
-- :doc:`guide/standalone` -- Track experiments from any Python script
-- :doc:`guide/lightning` -- Use with PyTorch Lightning Trainer or Fabric
-- :doc:`guide/artifacts` -- Upload models, checkpoints, and files
+Enable logging by adding this to ANY Python code:
 
+.. code-block:: python
 
-.. raw:: html
+   import litlogger
 
-   <hr class="docutils" style="margin: 50px 0 50px 0">
+   litlogger.init()
 
+   for i in range(10):
+       litlogger.log({"my_metric": i})
 
-API Reference
--------------
+   litlogger.finalize()
 
-- :doc:`api/experiment` -- Core experiment class for logging
-- :doc:`api/logger` -- Logger for PyTorch Lightning and Fabric
-- :doc:`api/module_api` -- Top-level functions (init, log, finalize)
+----
 
+APIs
+====
+
+LitLogger provides two APIs: a **standalone API** for any Python code, and an
+**Experiment** class for more control.
+
+Standalone API
+--------------
+
+The standalone API uses ``litlogger.init()`` and module-level functions. This
+is the recommended approach for most use cases.
+
+.. code-block:: python
+
+   import litlogger
+
+   litlogger.init(
+       name="my-experiment",
+       metadata={"model": "ResNet50", "lr": "0.001"},
+   )
+
+   for epoch in range(10):
+       litlogger.log_metrics({"loss": 1.0 / (epoch + 1)}, step=epoch)
+
+   litlogger.finalize()
+
+See :doc:`guide/standalone` for the full guide.
+
+Experiment
+----------
+
+``litlogger.init()`` returns an :class:`~litlogger.experiment.Experiment`
+instance. You can also create one directly for full control over the
+experiment lifecycle.
+
+.. code-block:: python
+
+   from litlogger import Experiment
+
+   exp = Experiment(
+       name="my-experiment",
+       metadata={"model": "ResNet50", "lr": "0.001"},
+   )
+
+   for epoch in range(10):
+       exp.log_metrics({"loss": 1.0 / (epoch + 1)}, step=epoch)
+
+   exp.log_file("config.yaml")
+   exp.log_model(model)
+   exp.finalize()
+
+See the :doc:`api/experiment` reference for all available methods.
+
+----
+
+PyTorch Lightning Integration
+=============================
+
+The ``LightningLogger`` class integrates directly with the PyTorch Lightning
+Trainer, so every ``self.log()`` call is automatically forwarded to
+Lightning.ai.
+
+.. code-block:: python
+
+   from lightning import Trainer
+   from litlogger import LightningLogger
+
+   logger = LightningLogger(
+       name="my-experiment",
+       metadata={"model": "ResNet50"},
+   )
+
+   trainer = Trainer(max_epochs=10, logger=logger)
+   trainer.fit(model, datamodule)
+
+See :doc:`guide/lightning` for the full guide.
+
+----
+
+View and Share Runs
+===================
+
+All experiments are collected in the "Experiments" tab in your Teamspace.
+
+.. image:: https://storage.googleapis.com/lightning-avatars/litpages/01j07an7zgc2ewmnnxj8gngg72/889a6cdd-c27f-499e-8d4b-6856e575e97a.png
+   :alt: Experiments tab in your Teamspace
+
+Open an experiment detail to share with everyone or specific users.
+
+.. image:: https://storage.googleapis.com/lightning-avatars/litpages/01j07an7zgc2ewmnnxj8gngg72/19d278b1-32a4-43ac-9a03-200aa0687e69.png
+   :alt: Sharing option for experiments
+
+----
+
+Third-Party Loggers
+===================
+
+Use any third-party logger you want with Lightning. However, LitLogger is free
+and native to the Lightning platform.
+
+----
 
 .. raw:: html
 
@@ -68,6 +183,7 @@ API Reference
     guide/lightning
     guide/artifacts
     guide/media
+    guide/examples
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -2,4 +2,30 @@
 Installation
 ############
 
-`pip install litlogger`
+LitLogger requires Python 3.10 or newer.
+
+From PyPI
+=========
+
+The recommended way to install LitLogger is from PyPI using ``pip`` or ``uv``:
+
+.. code-block:: bash
+
+   pip install litlogger
+
+.. code-block:: bash
+
+   uv add litlogger
+
+From Source (GitHub)
+====================
+
+To install the latest development version directly from GitHub:
+
+.. code-block:: bash
+
+   pip install git+https://github.com/Lightning-AI/litlogger.git
+
+.. code-block:: bash
+
+   uv add git+https://github.com/Lightning-AI/litlogger.git

--- a/examples/complete_workflow/fetch.py
+++ b/examples/complete_workflow/fetch.py
@@ -1,0 +1,27 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+import litlogger
+
+litlogger.init(name="image-classifier")
+
+metadata = litlogger.get_metadata()
+print(f"Metadata: {metadata}")
+
+litlogger.get_file("/tmp/config.json", remote_path="config.json")
+with open("/tmp/config.json") as f:
+    print(f"Config: {json.load(f)}")
+
+litlogger.finalize()

--- a/examples/complete_workflow/train.py
+++ b/examples/complete_workflow/train.py
@@ -1,0 +1,32 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+import litlogger
+
+config = {"model": "ResNet50", "lr": 0.001}
+with open("config.json", "w") as f:
+    json.dump(config, f)
+
+litlogger.init(
+    name="image-classifier",
+    metadata={"model": "ResNet50", "dataset": "CIFAR10"},
+)
+litlogger.log_file("config.json")
+
+for epoch in range(10):
+    # some dummy loss to mimic training
+    litlogger.log_metrics({"loss": 1.0 / (epoch + 1)}, step=epoch)
+
+litlogger.finalize()

--- a/examples/litserve_inference.py
+++ b/examples/litserve_inference.py
@@ -1,0 +1,50 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+
+import litgpt
+import litserve as ls
+from litlogger import LightningLogger
+
+
+class SimpleLitAPI(ls.LitAPI):
+    def setup(self, device):
+        self.llm = litgpt.LLM.load("EleutherAI/pythia-14m")
+        self.logger = LightningLogger(
+            name="litserve-inference",
+            metadata={"model": "pythia-14m"},
+        )
+
+    def decode_request(self, request):
+        return request["prompt"]
+
+    def predict(self, prompt):
+        start = time.perf_counter()
+        output = self.llm.generate(prompt, max_new_tokens=200)
+        self.logger.log_metrics(
+            {
+                "generation_time": time.perf_counter() - start,
+                "input_tokens": self.llm.preprocessor.encode(prompt).numel(),
+                "output_tokens": self.llm.preprocessor.encode(output).numel(),
+            }
+        )
+        return {"output": output}
+
+    def encode_response(self, output):
+        return {"output": output}
+
+
+if __name__ == "__main__":
+    server = ls.LitServer(SimpleLitAPI())
+    server.run(port=8000)


### PR DESCRIPTION
Adds basic contents for documentation based on manual written docs/guides as well as auto-generated api reference.

Example outputs are:
[litlogger-html.zip](https://github.com/user-attachments/files/25795036/litlogger-html.zip)
[litlogger.pdf](https://github.com/user-attachments/files/25795031/litlogger.pdf)
