### PR TITLE
Capture Git info from script if pwd is not in git repo

### DIFF
--- a/src/litlogger/diagnostics.py
+++ b/src/litlogger/diagnostics.py
@@ -160,7 +160,8 @@ def collect_system_info() -> dict:
     """
 
     # git
-    def get_git_info(command: List[str], default_message: str) -> str:
+    def get_git_info(command: List[str], default_message: str, fallback_cwd: str | None) -> str:
+        """Checks the git info of the current cwd. If not successful, then checks for the fallback_cwd."""
         try:
             return subprocess.check_output(
                 command,
@@ -168,13 +169,23 @@ def collect_system_info() -> dict:
                 stderr=subprocess.DEVNULL,
             ).strip()
         except subprocess.CalledProcessError:
-            return default_message
+            try:
+                return subprocess.check_output(command, text=True, stderr=subprocess.DEVNULL, cwd=fallback_cwd).strip()
+            except subprocess.CalledProcessError:
+                return default_message
+
+    script_path = os.path.abspath(sys.argv[0])
+    script_dir = os.path.dirname(script_path)
 
     # in case git is not installed
     try:
-        git_repo_name = get_git_info(["git", "rev-parse", "--show-toplevel"], "Not a git repository").split("/")[-1]
-        git_branch = get_git_info(["git", "rev-parse", "--abbrev-ref", "HEAD"], "No branch found")
-        git_commit_hash = get_git_info(["git", "rev-parse", "HEAD"], "No commit hash found")
+        git_repo_name = get_git_info(
+            ["git", "rev-parse", "--show-toplevel"], "Not a git repository", fallback_cwd=script_dir
+        ).split("/")[-1]
+        git_branch = get_git_info(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], "No branch found", fallback_cwd=script_dir
+        )
+        git_commit_hash = get_git_info(["git", "rev-parse", "HEAD"], "No commit hash found", fallback_cwd=script_dir)
     except FileNotFoundError:
         git_repo_name = None
         git_branch = None

--- a/src/litlogger/diagnostics.py
+++ b/src/litlogger/diagnostics.py
@@ -139,6 +139,21 @@ def get_cli_args() -> str:
     return " ".join(sys.argv[1:])
 
 
+def get_git_info(command: List[str], default_message: str, fallback_cwd: str | None) -> str:
+    """Checks the git info of the current cwd. If not successful, then checks for the fallback_cwd."""
+    try:
+        return subprocess.check_output(
+            command,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except subprocess.CalledProcessError:
+        try:
+            return subprocess.check_output(command, text=True, stderr=subprocess.DEVNULL, cwd=fallback_cwd).strip()
+        except subprocess.CalledProcessError:
+            return default_message
+
+
 def collect_system_info() -> dict:
     """Collect git, system, hardware, environment and CLI information.
 
@@ -158,22 +173,6 @@ def collect_system_info() -> dict:
           - Network I/O (psutil.net_io_counters())
           And add experiment.log_system_metrics() to log these metrics periodically.
     """
-
-    # git
-    def get_git_info(command: List[str], default_message: str, fallback_cwd: str | None) -> str:
-        """Checks the git info of the current cwd. If not successful, then checks for the fallback_cwd."""
-        try:
-            return subprocess.check_output(
-                command,
-                text=True,
-                stderr=subprocess.DEVNULL,
-            ).strip()
-        except subprocess.CalledProcessError:
-            try:
-                return subprocess.check_output(command, text=True, stderr=subprocess.DEVNULL, cwd=fallback_cwd).strip()
-            except subprocess.CalledProcessError:
-                return default_message
-
     script_path = os.path.abspath(sys.argv[0])
     script_dir = os.path.dirname(script_path)
 
@@ -200,7 +199,6 @@ def collect_system_info() -> dict:
     gpu_info = get_gpu_info()
 
     # args - capture python interpreter and script path (cli_args has the arguments separately)
-    script_path = os.path.abspath(sys.argv[0])
     execution_command = f"{sys.executable} {script_path}"
     cli_args = get_cli_args()
 

--- a/tests/unittests/test_diagnostics.py
+++ b/tests/unittests/test_diagnostics.py
@@ -8,9 +8,49 @@ from litlogger.diagnostics import (
     get_cpu_name,
     get_cuda_version,
     get_cudnn_version,
+    get_git_info,
     get_gpu_info,
     get_os_info,
 )
+
+
+class TestGetGitInfo:
+    """Test the get_git_info function."""
+
+    @patch("subprocess.check_output")
+    def test_success_on_first_try(self, mock_subprocess):
+        """Test that git info is returned from the cwd call."""
+        mock_subprocess.return_value = "main\n"
+        result = get_git_info(["git", "rev-parse", "--abbrev-ref", "HEAD"], "No branch found", fallback_cwd="/tmp")
+        assert result == "main"
+        mock_subprocess.assert_called_once()
+
+    @patch("subprocess.check_output")
+    def test_fallback_to_cwd(self, mock_subprocess):
+        """Test that git info falls back to fallback_cwd when cwd fails."""
+        mock_subprocess.side_effect = [
+            subprocess.CalledProcessError(1, "git"),
+            "develop\n",
+        ]
+        result = get_git_info(["git", "rev-parse", "--abbrev-ref", "HEAD"], "No branch found", fallback_cwd="/tmp")
+        assert result == "develop"
+        assert mock_subprocess.call_count == 2
+        # Second call should use fallback_cwd
+        assert mock_subprocess.call_args_list[1].kwargs["cwd"] == "/tmp"
+
+    @patch("subprocess.check_output")
+    def test_both_fail_returns_default(self, mock_subprocess):
+        """Test that the default message is returned when both cwd and fallback_cwd fail."""
+        mock_subprocess.side_effect = subprocess.CalledProcessError(1, "git")
+        result = get_git_info(["git", "rev-parse", "--abbrev-ref", "HEAD"], "No branch found", fallback_cwd="/tmp")
+        assert result == "No branch found"
+
+    @patch("subprocess.check_output")
+    def test_output_is_stripped(self, mock_subprocess):
+        """Test that whitespace is stripped from the output."""
+        mock_subprocess.return_value = "  main  \n"
+        result = get_git_info(["git", "rev-parse", "--abbrev-ref", "HEAD"], "No branch found", fallback_cwd=None)
+        assert result == "main"
 
 
 class TestSystemInfo:


### PR DESCRIPTION
If the CWD the script is launched from is not inside a git repo, we check the script dir for git details and only if that's not in a git repo either we don't record git information.

So now `python my_git_repo/my_script.py` will record git info from `my_git_repo` if the CWD is not already a git repo