### PR TITLE
Allow dynamically adding metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 dependencies = [
     "blake3",
-    "lightning-sdk >=2026.01.30",
+    "lightning-sdk >=2026.03.03",
     "litmodels >=0.1.8",
     "protobuf",
     "psutil",

--- a/src/litlogger/__init__.py
+++ b/src/litlogger/__init__.py
@@ -38,6 +38,7 @@ log_model = pre_init_callable("litlogger.log_model", Experiment.log_model)
 get_model = pre_init_callable("litlogger.get_model", Experiment.get_model)
 log_model_artifact = pre_init_callable("litlogger.log_model_artifact", Experiment.log_model_artifact)
 get_model_artifact = pre_init_callable("litlogger.get_model_artifact", Experiment.get_model_artifact)
+log_metadata = pre_init_callable("litlogger.log_metadata", Experiment.log_metadata)
 finalize = pre_init_callable("litlogger.finalize", Experiment.finalize)
 
 __all__ = [
@@ -55,6 +56,7 @@ __all__ = [
     "get_model_artifact",
     "finalize",
     "get_metadata",
+    "log_metadata",
 ]
 
 try:

--- a/src/litlogger/_module.py
+++ b/src/litlogger/_module.py
@@ -29,6 +29,7 @@ def set_global(
     get_model: Callable | None = None,
     log_model_artifact: Callable | None = None,
     get_model_artifact: Callable | None = None,
+    log_metadata: Callable | None = None,
     finalize: Callable | None = None,
 ) -> None:
     """Set global litlogger state after initialization."""
@@ -50,6 +51,8 @@ def set_global(
         litlogger.log_model_artifact = log_model_artifact
     if get_model_artifact:
         litlogger.get_model_artifact = get_model_artifact
+    if log_metadata:
+        litlogger.log_metadata = log_metadata
     if finalize:
         litlogger.finalize = finalize
 
@@ -66,6 +69,7 @@ def get_global() -> Dict[str, Any]:
         "get_model": litlogger.get_model,
         "log_model_artifact": litlogger.log_model_artifact,
         "get_model_artifact": litlogger.get_model_artifact,
+        "log_metadata": litlogger.log_metadata,
         "finalize": litlogger.finalize,
     }
 
@@ -83,4 +87,5 @@ def unset_globals() -> None:
     litlogger.get_model = pre_init_callable("litlogger.get_model", Experiment.get_model)
     litlogger.log_model_artifact = pre_init_callable("litlogger.log_model_artifact", Experiment.log_model_artifact)
     litlogger.get_model_artifact = pre_init_callable("litlogger.get_model_artifact", Experiment.get_model_artifact)
+    litlogger.log_metadata = pre_init_callable("litlogger.log_metadata", Experiment.log_metadata)
     litlogger.finalize = pre_init_callable("litlogger.finalize", Experiment.finalize)

--- a/src/litlogger/api/metrics_api.py
+++ b/src/litlogger/api/metrics_api.py
@@ -244,9 +244,7 @@ class MetricsApi:
         random_light_color, random_dark_color = _create_colors(name)
 
         # Convert metadata to tags
-        tags = []
-        if metadata:
-            tags = [V1MetricsTags(name=str(k), value=str(v), from_code=True, active=False) for k, v in metadata.items()]
+        tags = self._metadata_to_tags(metadata=metadata)
 
         # Create the stream
         cloudspace_id = os.getenv("LIGHTNING_CLOUD_SPACE_ID")
@@ -306,8 +304,12 @@ class MetricsApi:
         persisted: bool = True,
         phase: PhaseType = PhaseType.COMPLETED,
         trackers: Dict[str, MetricsTracker] | None = None,
+        metadata: Dict[str, str] | None = None,
     ) -> None:
-        """Update an experiment metrics store with completion status and trackers.
+        """Update an experiment metrics store with completion status, trackers, and/or metadata.
+
+        When ``metadata`` is ``None`` (the default), existing tags on the server are
+        left untouched.  Pass an explicit dict to replace the tags.
 
         Args:
             teamspace_id: The teamspace ID.
@@ -315,6 +317,8 @@ class MetricsApi:
             persisted: Whether the metrics have been persisted.
             phase: The phase of the metrics store (e.g., COMPLETED).
             trackers: Optional dictionary of metric trackers.
+            metadata: Optional metadata to attach to the experiment. If None,
+                existing tags are preserved.
         """
         # Convert user-facing phase and trackers to V1 types
         v1_phase = _to_v1_phase_type(phase)
@@ -329,6 +333,7 @@ class MetricsApi:
                 persisted=persisted,
                 phase=v1_phase,
                 trackers=v1_trackers,
+                tags=self._metadata_to_tags(metadata=metadata) if metadata is not None else None,
             ),
         )
 
@@ -345,3 +350,20 @@ class MetricsApi:
             return None
 
         return {name: _from_v1_metrics_tracker(v1_tracker) for name, v1_tracker in metrics_store.trackers.items()}
+
+    @staticmethod
+    def _metadata_to_tags(metadata: Dict[str, Any] | None) -> list[V1MetricsTags]:
+        """Convert a metadata dictionary to a list of V1MetricsTags.
+
+        Args:
+            metadata: Dictionary of metadata key-value pairs, or None.
+
+        Returns:
+            List of V1MetricsTags with ``from_code=True`` and ``active=True``,
+            or an empty list if metadata is None/empty.
+        """
+        tags = []
+        if metadata:
+            tags = [V1MetricsTags(name=str(k), value=str(v), from_code=True, active=True) for k, v in metadata.items()]
+
+        return tags

--- a/src/litlogger/background.py
+++ b/src/litlogger/background.py
@@ -287,7 +287,12 @@ class _BackgroundThread(Thread):
             )
 
     def inform_done(self) -> None:
-        """Inform the API that metrics collection is complete."""
+        """Inform the API that metrics collection is complete.
+
+        Sends the final update with phase=COMPLETED and accumulated trackers.
+        Metadata is intentionally omitted (None) so that tags set via
+        ``Experiment.log_metadata`` are preserved.
+        """
         self.metrics_api.update_experiment_metrics(
             teamspace_id=self.teamspace_id,
             metrics_store_id=self.metrics_store_id,

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -210,7 +210,7 @@ class Experiment:
         tags = getattr(self._metrics_store, "tags", None) or []
         return {tag.name: tag.value for tag in tags if tag.from_code}
 
-    def log_metrics(self, metrics: Dict[str, float], step: int | None = None, **kwargs: float) -> None:
+    def log_metrics(self, metrics: Dict[str, float] | None = None, step: int | None = None, **kwargs: float) -> None:
         """Log metrics to the experiment with background uploading.
 
         Metrics are buffered locally and uploaded to the cloud in batches to optimize performance.
@@ -230,6 +230,9 @@ class Experiment:
             raise self._manager.exception
 
         batch: Dict[str, Metrics] = {}
+
+        if metrics is None:
+            metrics = {}
 
         metrics.update(kwargs)
         for name, value in metrics.items():

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -272,12 +272,11 @@ class Experiment:
         if kwargs:
             current_tags.update(kwargs)
 
-        tags = self._metrics_api._metadata_to_tags(current_tags)
         self._metrics_api.update_experiment_metrics(
             teamspace_id=self._teamspace.id,
             metrics_store_id=self._metrics_store.id,
             phase=PhaseType.RUNNING,
-            metadata=tags,
+            metadata=current_tags,
         )
 
     def log_metrics_batch(self, metrics: Dict[str, List[Dict[str, float]]]) -> None:

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -653,7 +653,6 @@ class Experiment:
         resp = self._metrics_api.get_experiment_metrics_by_name(
             self._teamspace.id,
             name=self._metrics_store.name,
-            version_number=self._metrics_store.version_number,
         )
 
         if resp is not None:

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -35,7 +35,7 @@ from litlogger.api.media_api import MediaApi
 from litlogger.api.metrics_api import MetricsApi
 from litlogger.api.utils import _resolve_teamspace, build_experiment_url, get_accessible_url, get_guest_url
 from litlogger.artifacts import Artifact, Model, ModelArtifact
-from litlogger.background import _BackgroundThread
+from litlogger.background import PhaseType, _BackgroundThread
 from litlogger.capture import rerun_and_record
 from litlogger.printer import Printer, RunStats
 from litlogger.types import MediaType, Metrics, MetricValue
@@ -206,6 +206,7 @@ class Experiment:
         Returns:
             Dict[str, str]: The metadata dictionary with key-value pairs from code-defined tags.
         """
+        self._update_metrics_store()
         tags = getattr(self._metrics_store, "tags", None) or []
         return {tag.name: tag.value for tag in tags if tag.from_code}
 
@@ -251,6 +252,34 @@ class Experiment:
         if batch:
             self._metrics_queue.put(batch)
 
+    def log_metadata(self, metadata: Dict[str, str] | None = None, **kwargs: str) -> None:
+        """Add or update metadata tags on the experiment.
+
+        Merges the provided key-value pairs into the experiment's existing metadata
+        and pushes the update to the cloud immediately.
+
+        Args:
+            metadata: Dictionary of metadata key-value pairs to add or update.
+                Example: {"optimizer": "adam", "lr": "0.001"}.
+            **kwargs: Additional metadata as keyword arguments.
+                Example: optimizer="adam", lr="0.001".
+        """
+        current_tags = self.metadata
+
+        if metadata:
+            current_tags.update(metadata)
+
+        if kwargs:
+            current_tags.update(kwargs)
+
+        tags = self._metrics_api._metadata_to_tags(current_tags)
+        self._metrics_api.update_experiment_metrics(
+            teamspace_id=self._teamspace.id,
+            metrics_store_id=self._metrics_store.id,
+            phase=PhaseType.RUNNING,
+            metadata=tags,
+        )
+
     def log_metrics_batch(self, metrics: Dict[str, List[Dict[str, float]]]) -> None:
         """Log a batch of metrics through the background queue.
 
@@ -292,19 +321,6 @@ class Experiment:
             batch[name] = Metrics(name=name, values=metric_values)
 
         self._metrics_queue.put(batch)
-
-    def _signal_handler(self, signum: int, frame: FrameType | None) -> None:
-        """Handle termination signals by calling finalize().
-
-        Args:
-            signum: Signal number.
-            frame: Current stack frame (unused).
-        """
-        # Call finalize and then exit with appropriate code
-        # For SIGTERM (15) and SIGINT (2), exit with 128 + signal number
-        # This follows the convention for signal-induced termination
-        self.finalize()
-        sys.exit(128 + signum)
 
     def finalize(self, status: str | None = None, print_summary: bool = True) -> None:
         """Finalize the experiment and upload all remaining metrics.
@@ -630,3 +646,29 @@ class Experiment:
             url=self._url,
             metadata=self.metadata,
         )
+
+    # -- Private helpers -------------------------------------------------------
+
+    def _update_metrics_store(self) -> None:
+        """Re-fetch the metrics store from the API to refresh local state (tags, trackers, etc.)."""
+        resp = self._metrics_api.get_experiment_metrics_by_name(
+            self._teamspace.id,
+            name=self._metrics_store.name,
+            version_number=self._metrics_store.version_number,
+        )
+
+        if resp is not None:
+            self._metrics_store = resp
+
+    def _signal_handler(self, signum: int, frame: FrameType | None) -> None:
+        """Handle termination signals by calling finalize().
+
+        Args:
+            signum: Signal number.
+            frame: Current stack frame (unused).
+        """
+        # Call finalize and then exit with appropriate code
+        # For SIGTERM (15) and SIGINT (2), exit with 128 + signal number
+        # This follows the convention for signal-induced termination
+        self.finalize()
+        sys.exit(128 + signum)

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -646,8 +646,6 @@ class Experiment:
             metadata=self.metadata,
         )
 
-    # -- Private helpers -------------------------------------------------------
-
     def _update_metrics_store(self) -> None:
         """Re-fetch the metrics store from the API to refresh local state (tags, trackers, etc.)."""
         resp = self._metrics_api.get_experiment_metrics_by_name(

--- a/src/litlogger/init.py
+++ b/src/litlogger/init.py
@@ -112,6 +112,7 @@ def init(
         log_model_artifact=experiment.log_model_artifact,
         get_model_artifact=experiment.get_model_artifact,
         finalize=experiment.finalize,
+        log_metadata=experiment.log_metadata,
     )
 
     if print_url:

--- a/tests/unittests/api/test_metrics_api.py
+++ b/tests/unittests/api/test_metrics_api.py
@@ -48,27 +48,6 @@ class TestMetricsApi:
         assert result.id == "ms-123"
         assert result.name == "my-experiment"
 
-    def test_get_experiment_metrics_by_name_returns_first_match(self):
-        """Test that get_experiment_metrics_by_name returns the first match when multiple exist."""
-        mock_client = MagicMock()
-        mock_stream_1 = MagicMock()
-        mock_stream_1.id = "ms-123"
-        mock_stream_1.name = "my-experiment"
-        mock_stream_2 = MagicMock()
-        mock_stream_2.id = "ms-456"
-        mock_stream_2.name = "my-experiment"
-        mock_response = MagicMock()
-        mock_response.metrics_streams = [mock_stream_1, mock_stream_2]
-        mock_client.lit_logger_service_list_metrics_streams.return_value = mock_response
-        api = MetricsApi(client=mock_client)
-
-        result = api.get_experiment_metrics_by_name(
-            teamspace_id="ts-123",
-            name="my-experiment",
-        )
-
-        assert result.id == "ms-123"
-
     def test_get_experiment_metrics_by_name_not_found(self):
         """Test that get_experiment_metrics_by_name returns None when experiment not found."""
         mock_client = MagicMock()

--- a/tests/unittests/test_experiment.py
+++ b/tests/unittests/test_experiment.py
@@ -862,16 +862,7 @@ class TestExperimentLogMetadata:
         exp._metrics_store = MagicMock()
         exp._metrics_store.id = "store_123"
         exp._metrics_store.name = "test"
-        exp._metrics_store.version_number = 1
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_experiment_metrics_by_name.return_value = exp._metrics_store
-
-        # Existing from_code tag
-        existing_tag = MagicMock()
-        existing_tag.name = "lr"
-        existing_tag.value = "0.001"
-        existing_tag.from_code = True
-        exp._metrics_store.tags = [existing_tag]
 
         exp._teamspace = MagicMock()
         exp._teamspace.id = "ts_123"
@@ -882,9 +873,6 @@ class TestExperimentLogMetadata:
         from litlogger.experiment import Experiment
 
         Experiment.log_metadata(exp, {"batch_size": "32"})
-
-        # Verify _update_metrics_store was called
-        exp._update_metrics_store.assert_called_once()
 
         # Verify update_experiment_metrics was called with merged metadata
         exp._metrics_api.update_experiment_metrics.assert_called_once()
@@ -900,9 +888,7 @@ class TestExperimentLogMetadata:
         exp._metrics_store = MagicMock()
         exp._metrics_store.id = "store_123"
         exp._metrics_store.name = "test"
-        exp._metrics_store.version_number = 1
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_experiment_metrics_by_name.return_value = exp._metrics_store
 
         exp._teamspace = MagicMock()
         exp._teamspace.id = "ts_123"
@@ -937,7 +923,7 @@ class TestUpdateMetricsStore:
 
         Experiment._update_metrics_store(exp)
 
-        exp._metrics_api.get_experiment_metrics_by_name.assert_called_once_with("ts_123", name="test", version_number=1)
+        exp._metrics_api.get_experiment_metrics_by_name.assert_called_once_with("ts_123", name="test")
         assert exp._metrics_store is new_store
 
     def test_update_metrics_store_keeps_old_on_none(self):
@@ -1047,7 +1033,6 @@ class TestExperimentStatsTracking:
         mock_model_artifact_class.return_value = MagicMock()
         exp = MagicMock()
         exp.name = "test"
-        exp.version = "v1"
         exp._teamspace = MagicMock()
         exp._stats = MagicMock()
         exp._stats.models_logged = 0
@@ -1063,7 +1048,6 @@ class TestExperimentStatsTracking:
         mock_model_class.return_value = MagicMock()
         exp = MagicMock()
         exp.name = "test"
-        exp.version = "v1"
         exp._teamspace = MagicMock()
         exp._stats = MagicMock()
         exp._stats.models_logged = 0
@@ -1081,7 +1065,6 @@ class TestExperimentPrintUrl:
         """Test that print_url delegates to printer with correct args."""
         exp = MagicMock()
         exp.name = "my-experiment"
-        exp.version = "v1"
         exp._teamspace = MagicMock()
         exp._teamspace.name = "my-teamspace"
         exp._url = "https://lightning.ai/my-experiment"
@@ -1103,7 +1086,6 @@ class TestExperimentPrintUrl:
         assert call_kwargs["name"] == "my-experiment"
         assert call_kwargs["teamspace"] == "my-teamspace"
         assert call_kwargs["url"] == "https://lightning.ai/my-experiment"
-        assert call_kwargs["version"] == "v1"
 
 
 class TestExperimentLogMetricsBatchCreatedAt:

--- a/tests/unittests/test_experiment.py
+++ b/tests/unittests/test_experiment.py
@@ -774,3 +774,385 @@ class TestExperimentLogMedia:
 
         with patch("os.path.exists", return_value=False), pytest.raises(FileNotFoundError):
             Experiment.log_media(exp, "file", "/non/existent/file.png")
+
+    def test_log_media_with_step_epoch_caption(self):
+        """Test log_media passes step, epoch, and caption to upload_media."""
+        exp = MagicMock()
+        exp._media_api = MagicMock()
+        exp._printer = MagicMock()
+        exp._stats = MagicMock()
+        exp._stats.media_logged = 0
+
+        from unittest.mock import patch
+
+        from litlogger.experiment import Experiment
+        from litlogger.types import MediaType
+
+        with patch("os.path.exists", return_value=True):
+            Experiment.log_media(
+                exp,
+                "img",
+                "/path/to/img.png",
+                kind=MediaType.IMAGE,
+                step=5,
+                epoch=2,
+                caption="A caption",
+            )
+
+        _, kwargs = exp._media_api.upload_media.call_args
+        assert kwargs["step"] == 5
+        assert kwargs["epoch"] == 2
+        assert kwargs["caption"] == "A caption"
+
+
+class TestExperimentMetadataProperty:
+    """Test metadata property."""
+
+    def test_metadata_returns_from_code_tags(self):
+        """Test that metadata property filters to from_code tags only."""
+        exp = MagicMock()
+        tag1 = MagicMock()
+        tag1.name = "lr"
+        tag1.value = "0.001"
+        tag1.from_code = True
+        tag2 = MagicMock()
+        tag2.name = "ui_tag"
+        tag2.value = "ignored"
+        tag2.from_code = False
+        tag3 = MagicMock()
+        tag3.name = "batch_size"
+        tag3.value = "32"
+        tag3.from_code = True
+        exp._metrics_store = MagicMock()
+        exp._metrics_store.tags = [tag1, tag2, tag3]
+
+        from litlogger.experiment import Experiment
+
+        result = Experiment.metadata.fget(exp)
+        assert result == {"lr": "0.001", "batch_size": "32"}
+
+    def test_metadata_returns_empty_when_no_tags(self):
+        """Test that metadata property returns empty dict when tags is None."""
+        exp = MagicMock()
+        exp._metrics_store = MagicMock(spec=[])  # no tags attribute
+
+        from litlogger.experiment import Experiment
+
+        result = Experiment.metadata.fget(exp)
+        assert result == {}
+
+    def test_metadata_returns_empty_for_empty_tags_list(self):
+        """Test that metadata property returns empty dict for empty tags list."""
+        exp = MagicMock()
+        exp._metrics_store = MagicMock()
+        exp._metrics_store.tags = []
+
+        from litlogger.experiment import Experiment
+
+        result = Experiment.metadata.fget(exp)
+        assert result == {}
+
+
+class TestExperimentLogMetadata:
+    """Test log_metadata method."""
+
+    def test_log_metadata_updates_tags(self):
+        """Test that log_metadata merges new metadata with existing."""
+        exp = MagicMock()
+        exp._metrics_store = MagicMock()
+        exp._metrics_store.id = "store_123"
+        exp._metrics_store.name = "test"
+        exp._metrics_store.version_number = 1
+        exp._metrics_api = MagicMock()
+        exp._metrics_api.get_experiment_metrics_by_name.return_value = exp._metrics_store
+
+        # Existing from_code tag
+        existing_tag = MagicMock()
+        existing_tag.name = "lr"
+        existing_tag.value = "0.001"
+        existing_tag.from_code = True
+        exp._metrics_store.tags = [existing_tag]
+
+        exp._teamspace = MagicMock()
+        exp._teamspace.id = "ts_123"
+        # metadata property can't work via MagicMock, so set it directly
+        exp.metadata = {"lr": "0.001"}
+
+        from litlogger.background import PhaseType
+        from litlogger.experiment import Experiment
+
+        Experiment.log_metadata(exp, {"batch_size": "32"})
+
+        # Verify _update_metrics_store was called
+        exp._update_metrics_store.assert_called_once()
+
+        # Verify update_experiment_metrics was called with merged metadata
+        exp._metrics_api.update_experiment_metrics.assert_called_once()
+        call_kwargs = exp._metrics_api.update_experiment_metrics.call_args.kwargs
+        assert call_kwargs["teamspace_id"] == "ts_123"
+        assert call_kwargs["metrics_store_id"] == "store_123"
+        assert call_kwargs["phase"] == PhaseType.RUNNING
+        assert call_kwargs["metadata"] == {"lr": "0.001", "batch_size": "32"}
+
+    def test_log_metadata_overwrites_existing_key(self):
+        """Test that log_metadata overwrites existing keys."""
+        exp = MagicMock()
+        exp._metrics_store = MagicMock()
+        exp._metrics_store.id = "store_123"
+        exp._metrics_store.name = "test"
+        exp._metrics_store.version_number = 1
+        exp._metrics_api = MagicMock()
+        exp._metrics_api.get_experiment_metrics_by_name.return_value = exp._metrics_store
+
+        exp._teamspace = MagicMock()
+        exp._teamspace.id = "ts_123"
+        # metadata property can't work via MagicMock, so set it directly
+        exp.metadata = {"lr": "0.001"}
+
+        from litlogger.experiment import Experiment
+
+        Experiment.log_metadata(exp, {"lr": "0.01"})
+
+        call_kwargs = exp._metrics_api.update_experiment_metrics.call_args.kwargs
+        assert call_kwargs["metadata"] == {"lr": "0.01"}
+
+
+class TestUpdateMetricsStore:
+    """Test _update_metrics_store method."""
+
+    def test_update_metrics_store_refreshes(self):
+        """Test that _update_metrics_store refreshes from API."""
+        exp = MagicMock()
+        exp._metrics_store = MagicMock()
+        exp._metrics_store.name = "test"
+        exp._metrics_store.version_number = 1
+        exp._teamspace = MagicMock()
+        exp._teamspace.id = "ts_123"
+
+        new_store = MagicMock()
+        exp._metrics_api = MagicMock()
+        exp._metrics_api.get_experiment_metrics_by_name.return_value = new_store
+
+        from litlogger.experiment import Experiment
+
+        Experiment._update_metrics_store(exp)
+
+        exp._metrics_api.get_experiment_metrics_by_name.assert_called_once_with("ts_123", name="test", version_number=1)
+        assert exp._metrics_store is new_store
+
+    def test_update_metrics_store_keeps_old_on_none(self):
+        """Test that _update_metrics_store keeps old store if API returns None."""
+        exp = MagicMock()
+        old_store = MagicMock()
+        exp._metrics_store = old_store
+        exp._metrics_store.name = "test"
+        exp._metrics_store.version_number = 1
+        exp._teamspace = MagicMock()
+        exp._teamspace.id = "ts_123"
+
+        exp._metrics_api = MagicMock()
+        exp._metrics_api.get_experiment_metrics_by_name.return_value = None
+
+        from litlogger.experiment import Experiment
+
+        Experiment._update_metrics_store(exp)
+
+        # Should not overwrite with None
+        assert exp._metrics_store is old_store
+
+
+class TestExperimentLogMetricsKwargs:
+    """Test log_metrics with kwargs."""
+
+    def test_log_metrics_with_kwargs(self):
+        """Test log_metrics accepts kwargs alongside metrics dict."""
+        exp = MagicMock()
+        exp._manager = MagicMock()
+        exp._manager.exception = None
+        exp.store_step = True
+        exp.store_created_at = False
+        exp._metrics_queue = MagicMock()
+        exp._stats = MagicMock()
+
+        from litlogger.experiment import Experiment
+
+        Experiment.log_metrics(exp, {"loss": 0.5}, step=1, accuracy=0.9)
+
+        call_args = exp._metrics_queue.put.call_args[0][0]
+        assert "loss" in call_args
+        assert "accuracy" in call_args
+        assert call_args["loss"].values[0].value == 0.5
+        assert call_args["accuracy"].values[0].value == 0.9
+
+    def test_log_metrics_kwargs_override_dict(self):
+        """Test that kwargs override dict values for same key."""
+        exp = MagicMock()
+        exp._manager = MagicMock()
+        exp._manager.exception = None
+        exp.store_step = False
+        exp.store_created_at = False
+        exp._metrics_queue = MagicMock()
+        exp._stats = MagicMock()
+
+        from litlogger.experiment import Experiment
+
+        Experiment.log_metrics(exp, {"loss": 0.5}, loss=0.3)
+
+        call_args = exp._metrics_queue.put.call_args[0][0]
+        assert call_args["loss"].values[0].value == 0.3
+
+
+class TestExperimentStatsTracking:
+    """Test that experiment methods track stats correctly."""
+
+    def test_log_metrics_tracks_stats(self):
+        """Test log_metrics calls record_metric on stats."""
+        exp = MagicMock()
+        exp._manager = MagicMock()
+        exp._manager.exception = None
+        exp.store_step = True
+        exp.store_created_at = False
+        exp._metrics_queue = MagicMock()
+        exp._stats = MagicMock()
+
+        from litlogger.experiment import Experiment
+
+        Experiment.log_metrics(exp, {"loss": 0.5, "acc": 0.9}, step=1)
+
+        assert exp._stats.record_metric.call_count == 2
+        calls = {c.args[0]: c.args[1] for c in exp._stats.record_metric.call_args_list}
+        assert calls["loss"] == 0.5
+        assert calls["acc"] == 0.9
+
+    @patch.object(experiment_module, "Artifact")
+    def test_log_file_tracks_artifact_count(self, mock_artifact_class):
+        """Test log_file increments artifacts_logged."""
+        mock_artifact_class.return_value = MagicMock()
+        exp = MagicMock()
+        exp.name = "test"
+        exp._teamspace = MagicMock()
+        exp._metrics_store = MagicMock()
+        exp._artifacts_api = MagicMock()
+        exp._stats = MagicMock()
+        exp._stats.artifacts_logged = 0
+
+        from litlogger.experiment import Experiment
+
+        Experiment.log_file(exp, "file.txt", verbose=False)
+        assert exp._stats.artifacts_logged == 1
+
+    @patch.object(experiment_module, "ModelArtifact")
+    def test_log_model_artifact_tracks_model_count(self, mock_model_artifact_class):
+        """Test log_model_artifact increments models_logged."""
+        mock_model_artifact_class.return_value = MagicMock()
+        exp = MagicMock()
+        exp.name = "test"
+        exp.version = "v1"
+        exp._teamspace = MagicMock()
+        exp._stats = MagicMock()
+        exp._stats.models_logged = 0
+
+        from litlogger.experiment import Experiment
+
+        Experiment.log_model_artifact(exp, "model.pt", verbose=False)
+        assert exp._stats.models_logged == 1
+
+    @patch.object(experiment_module, "Model")
+    def test_log_model_tracks_model_count(self, mock_model_class):
+        """Test log_model increments models_logged."""
+        mock_model_class.return_value = MagicMock()
+        exp = MagicMock()
+        exp.name = "test"
+        exp.version = "v1"
+        exp._teamspace = MagicMock()
+        exp._stats = MagicMock()
+        exp._stats.models_logged = 0
+
+        from litlogger.experiment import Experiment
+
+        Experiment.log_model(exp, MagicMock(), verbose=False)
+        assert exp._stats.models_logged == 1
+
+
+class TestExperimentPrintUrl:
+    """Test print_url method."""
+
+    def test_print_url_calls_printer(self):
+        """Test that print_url delegates to printer with correct args."""
+        exp = MagicMock()
+        exp.name = "my-experiment"
+        exp.version = "v1"
+        exp._teamspace = MagicMock()
+        exp._teamspace.name = "my-teamspace"
+        exp._url = "https://lightning.ai/my-experiment"
+
+        # Set up metadata property to return dict
+        tag = MagicMock()
+        tag.name = "lr"
+        tag.value = "0.001"
+        tag.from_code = True
+        exp._metrics_store = MagicMock()
+        exp._metrics_store.tags = [tag]
+
+        from litlogger.experiment import Experiment
+
+        Experiment.print_url(exp)
+
+        exp._printer.experiment_start.assert_called_once()
+        call_kwargs = exp._printer.experiment_start.call_args.kwargs
+        assert call_kwargs["name"] == "my-experiment"
+        assert call_kwargs["teamspace"] == "my-teamspace"
+        assert call_kwargs["url"] == "https://lightning.ai/my-experiment"
+        assert call_kwargs["version"] == "v1"
+
+
+class TestExperimentLogMetricsBatchCreatedAt:
+    """Test log_metrics_batch with store_created_at."""
+
+    def test_log_metrics_batch_with_store_created_at(self):
+        """Test that log_metrics_batch sets created_at when store_created_at=True."""
+        exp = MagicMock()
+        exp._manager = MagicMock()
+        exp._manager.exception = None
+        exp._metrics_queue = MagicMock()
+        exp.store_created_at = True
+
+        from litlogger.experiment import Experiment
+
+        metrics = {"loss": [{"step": 0, "value": 1.0}]}
+        Experiment.log_metrics_batch(exp, metrics)
+
+        batch = exp._metrics_queue.put.call_args[0][0]
+        assert batch["loss"].values[0].created_at is not None
+
+    def test_log_metrics_batch_without_store_created_at(self):
+        """Test that log_metrics_batch does not set created_at when store_created_at=False."""
+        exp = MagicMock()
+        exp._manager = MagicMock()
+        exp._manager.exception = None
+        exp._metrics_queue = MagicMock()
+        exp.store_created_at = False
+
+        from litlogger.experiment import Experiment
+
+        metrics = {"loss": [{"step": 0, "value": 1.0}]}
+        Experiment.log_metrics_batch(exp, metrics)
+
+        batch = exp._metrics_queue.put.call_args[0][0]
+        assert batch["loss"].values[0].created_at is None
+
+    def test_log_metrics_batch_without_step_key(self):
+        """Test that log_metrics_batch handles missing step key."""
+        exp = MagicMock()
+        exp._manager = MagicMock()
+        exp._manager.exception = None
+        exp._metrics_queue = MagicMock()
+        exp.store_created_at = False
+
+        from litlogger.experiment import Experiment
+
+        metrics = {"loss": [{"value": 1.0}]}
+        Experiment.log_metrics_batch(exp, metrics)
+
+        batch = exp._metrics_queue.put.call_args[0][0]
+        assert batch["loss"].values[0].step is None

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -60,6 +60,7 @@ class TestInit:
             log_model_artifact=mock_experiment.log_model_artifact,
             get_model_artifact=mock_experiment.get_model_artifact,
             finalize=mock_experiment.finalize,
+            log_metadata=mock_experiment.log_metadata,
         )
 
         assert result is mock_experiment


### PR DESCRIPTION
allows something like this:

```python
import litlogger

litlogger.init("dummy", metadata={"a": "a", "b": "b"})

for i in range(10):
    litlogger.log({"metric": i})

litlogger.log_metadata({"c": "c"})

litlogger.finalize()

# simulate resuming
litlogger.init("dummy")

for i in range(10):
    litlogger.log({"metric": i})

litlogger.log_metadata(d="d")
litlogger.finalize()
```