### PR TITLE
Update version number to 2026.03.09

### DIFF
--- a/src/litlogger/__init__.py
+++ b/src/litlogger/__init__.py
@@ -18,7 +18,7 @@ For guides and examples, see https://lightning.ai.
 For reference documentation, see https://github.com/Lightning-AI/litlogger.
 """
 
-__version__ = "0.1.7"
+__version__ = "2026.03.09"
 
 # Import core classes
 # Import preinit utilities


### PR DESCRIPTION
Updated the `__version__` from `"0.1.7"` to `"2026.03.09"` in `src/litlogger/__init__.py`. Switches to date-based versioning.