### PR TITLE
Update push_wheel.yaml to include id-token permission

### DIFF
--- a/.github/workflows/push_wheel.yaml
+++ b/.github/workflows/push_wheel.yaml
@@ -15,7 +15,10 @@ jobs:
   # based on https://github.com/pypa/gh-action-pypi-publish
   build-package:
     runs-on: "ubuntu-22.04"
-    timeout-minutes: 10
+    timeout-minutes: 10    
+    # IMPORTANT: this permission is mandatory for Trusted Publishing
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v5
     - uses: actions/setup-python@v5


### PR DESCRIPTION
Added permissions for Trusted Publishing in GitHub Actions.