### PR TITLE
Deprecate Lightning Logger Class

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,7 +9,7 @@ This reference documents the public LitLogger surface:
 - the :class:`~litlogger.experiment.Experiment` class
 - file, media, and model wrappers
 - series and public enums
-- :class:`~litlogger.logger.LightningLogger`
+- :class:`~litlogger.logger.LightningLogger` (deprecated compatibility alias)
 
 Initialization
 ==============
@@ -107,6 +107,11 @@ LightningLogger
 ===============
 
 .. currentmodule:: litlogger.logger
+
+Deprecated compatibility alias for Lightning/Fabric integration. Prefer
+:class:`lightning:lightning.pytorch.loggers.LitLogger`, or use
+:func:`litlogger.init.init` and the dict-style
+:class:`~litlogger.experiment.Experiment` API for standalone usage.
 
 .. autoclass:: LightningLogger
    :members:

--- a/docs/source/guide/artifacts.rst
+++ b/docs/source/guide/artifacts.rst
@@ -107,6 +107,7 @@ Download model artifacts back:
 Automatic Checkpoint Logging
 ============================
 
-When using :class:`~litlogger.logger.LightningLogger` with ``log_model=True``,
+When using :class:`lightning:lightning.pytorch.loggers.LitLogger` with
+``log_model=True``,
 checkpoints saved by Lightning's ``ModelCheckpoint`` callback are
 automatically uploaded as model artifacts.

--- a/docs/source/guide/examples.rst
+++ b/docs/source/guide/examples.rst
@@ -28,7 +28,7 @@ and the new ``Model`` API for artifacts, objects, and checkpoint series.
 PyTorch Lightning
 =================
 
-An MNIST autoencoder trained with PyTorch Lightning and ``LightningLogger``.
+An MNIST autoencoder trained with PyTorch Lightning and upstream ``LitLogger``.
 
 .. literalinclude:: ../../../examples/lightning_autoencoder.py
    :language: python

--- a/docs/source/guide/lightning.rst
+++ b/docs/source/guide/lightning.rst
@@ -2,23 +2,23 @@
 Lightning Integration
 #######################
 
-:class:`~litlogger.logger.LightningLogger` plugs directly into the PyTorch
-Lightning ``Trainer`` and Lightning Fabric, streaming metrics, metadata,
-artifacts, media, and models to `lightning.ai <https://lightning.ai>`_.
+Use :class:`lightning:lightning.pytorch.loggers.LitLogger` for Trainer and
+Fabric integration. :class:`~litlogger.logger.LightningLogger` remains
+available only as a deprecated compatibility alias.
 
 Using with Trainer
 ==================
 
-Pass a :class:`~litlogger.logger.LightningLogger` as the ``logger`` argument to
-the Trainer. Every ``self.log()`` call inside your LightningModule is
-forwarded automatically.
+Pass :class:`lightning:lightning.pytorch.loggers.LitLogger` as the ``logger``
+argument to the Trainer. Every ``self.log()`` call inside your LightningModule
+is forwarded automatically.
 
 .. code-block:: python
 
    from lightning import Trainer
-   from litlogger import LightningLogger
+   from lightning.pytorch.loggers import LitLogger
 
-   logger = LightningLogger(name="cifar10-resnet")
+   logger = LitLogger(name="cifar10-resnet")
    trainer = Trainer(max_epochs=10, logger=logger)
    trainer.fit(model, datamodule)
 
@@ -42,7 +42,7 @@ You can also pass metadata directly:
 
 .. code-block:: python
 
-   logger = LightningLogger(
+   logger = LitLogger(
        name="cifar10-resnet",
        metadata={"optimizer": "AdamW", "scheduler": "cosine"},
    )
@@ -58,7 +58,7 @@ registry whenever Lightning saves a checkpoint.
    from lightning.pytorch.callbacks import ModelCheckpoint
 
    checkpoint_cb = ModelCheckpoint(save_top_k=2, monitor="val_loss")
-   logger = LightningLogger(name="my-model", log_model=True)
+   logger = LitLogger(name="my-model", log_model=True)
 
    trainer = Trainer(
        max_epochs=20,
@@ -70,14 +70,15 @@ registry whenever Lightning saves a checkpoint.
 Using with Fabric
 =================
 
-:class:`~litlogger.logger.LightningLogger` also works as a Fabric logger:
+:class:`lightning:lightning.pytorch.loggers.LitLogger` also works as a Fabric
+logger:
 
 .. code-block:: python
 
    import lightning as L
-   from litlogger import LightningLogger
+   from lightning.pytorch.loggers import LitLogger
 
-   logger = LightningLogger(name="fabric-run")
+   logger = LitLogger(name="fabric-run")
    fabric = L.Fabric(loggers=[logger])
    fabric.launch()
 
@@ -101,7 +102,7 @@ Accessing the Experiment URL
 
 .. code-block:: python
 
-   logger = LightningLogger(name="my-run")
+   logger = LitLogger(name="my-run")
    trainer = Trainer(logger=logger)
    trainer.fit(model, datamodule)
 

--- a/docs/source/guide/media.rst
+++ b/docs/source/guide/media.rst
@@ -25,8 +25,8 @@ New Dict-Style API
 Legacy Helper API
 =================
 
-The legacy helper method remains available and is still what
-:class:`~litlogger.logger.LightningLogger` exposes directly.
+The legacy helper method remains available for existing code, but new
+standalone code should prefer the dict-style wrappers.
 
 Logging Images
 ==============
@@ -75,18 +75,19 @@ Supported Types
 When ``kind`` is not provided, LitLogger guesses the type from the file's MIME
 type. If the type cannot be determined, a ``ValueError`` is raised.
 
-Using with LightningLogger
-==========================
+Deprecated Compatibility Logger
+===============================
 
-The :class:`~litlogger.logger.LightningLogger` exposes the same
-:meth:`litlogger.log_media() <litlogger.experiment.Experiment.log_media>`
-method, which you can call from callbacks or your LightningModule:
+:class:`~litlogger.logger.LightningLogger` is deprecated. For Lightning or
+Fabric integrations, prefer
+:class:`lightning:lightning.pytorch.loggers.LitLogger` and use its media
+helpers from callbacks or your LightningModule.
 
 .. code-block:: python
 
-   from litlogger import LightningLogger
+   from lightning.pytorch.loggers import LitLogger
 
-   logger = LightningLogger(name="vision-run")
+   logger = LitLogger(name="vision-run")
 
    logger.log_media(
        "val_sample",

--- a/docs/source/guide/workflows.rst
+++ b/docs/source/guide/workflows.rst
@@ -31,7 +31,9 @@ user-facing API going forward.
 Lightning and Fabric
 ====================
 
-Use :class:`~litlogger.logger.LightningLogger` with a Trainer or Fabric loop.
+Use :class:`lightning:lightning.pytorch.loggers.LitLogger` with a Trainer or
+Fabric loop. The local :class:`~litlogger.logger.LightningLogger` alias is
+deprecated.
 
 Files, Media, and Models
 ========================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,7 +35,7 @@ LitLogger currently supports these main workflows:
 
 - standalone logging with the dict-style ``Experiment`` API
 - legacy module-level logging helpers for existing scripts
-- Lightning and Fabric integration through :class:`~litlogger.logger.LightningLogger`
+- Lightning and Fabric integration through upstream ``LitLogger`` classes
 - file, image, text, and model logging through dedicated wrappers
 - experiment resume and later retrieval by name
 - inference logging from a LitServe endpoint

--- a/docs/source/tutorials/lightning.rst
+++ b/docs/source/tutorials/lightning.rst
@@ -2,8 +2,10 @@
 Lightning Tutorial
 ##################
 
-Use :class:`~litlogger.logger.LightningLogger` when you want Lightning or
-Fabric to drive experiment logging for you.
+Use :class:`lightning:lightning.pytorch.loggers.LitLogger` when you want
+Lightning or Fabric to drive experiment logging for you.
+:class:`~litlogger.logger.LightningLogger` is deprecated and remains only as a
+compatibility alias.
 
 Trainer Integration
 ===================
@@ -11,9 +13,9 @@ Trainer Integration
 .. code-block:: python
 
    from lightning import Trainer
-   from litlogger import LightningLogger
+   from lightning.pytorch.loggers import LitLogger
 
-   logger = LightningLogger(
+   logger = LitLogger(
        name="mnist-autoencoder",
        metadata={"dataset": "mnist"},
    )
@@ -47,7 +49,7 @@ Enable automatic checkpoint uploads with ``log_model=True``.
 
 .. code-block:: python
 
-   logger = LightningLogger(name="my-model", log_model=True)
+   logger = LitLogger(name="my-model", log_model=True)
 
    trainer = Trainer(
        logger=logger,

--- a/examples/lightning_autoencoder.py
+++ b/examples/lightning_autoencoder.py
@@ -14,7 +14,7 @@
 import os
 
 import lightning as L
-from litlogger import LightningLogger
+from lightning.pytorch.loggers import LitLogger
 from torch import nn, optim
 from torch.utils.data import DataLoader
 from torchvision.datasets import MNIST
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     )
 
     # configure the logger
-    lit_logger = LightningLogger()
+    lit_logger = LitLogger()
 
     # pass logger to the Trainer
     trainer = L.Trainer(

--- a/examples/litserve_inference.py
+++ b/examples/litserve_inference.py
@@ -14,14 +14,14 @@
 import time
 
 import litgpt
+import litlogger
 import litserve as ls
-from litlogger import LightningLogger
 
 
 class SimpleLitAPI(ls.LitAPI):
     def setup(self, device):
         self.llm = litgpt.LLM.load("EleutherAI/pythia-14m")
-        self.logger = LightningLogger(
+        self.experiment = litlogger.init(
             name="litserve-inference",
             metadata={"model": "pythia-14m"},
         )
@@ -32,17 +32,16 @@ class SimpleLitAPI(ls.LitAPI):
     def predict(self, prompt):
         start = time.perf_counter()
         output = self.llm.generate(prompt, max_new_tokens=200)
-        self.logger.log_metrics(
-            {
-                "generation_time": time.perf_counter() - start,
-                "input_tokens": self.llm.preprocessor.encode(prompt).numel(),
-                "output_tokens": self.llm.preprocessor.encode(output).numel(),
-            }
-        )
+        self.experiment["generation_time"].append(time.perf_counter() - start)
+        self.experiment["input_tokens"].append(self.llm.preprocessor.encode(prompt).numel())
+        self.experiment["output_tokens"].append(self.llm.preprocessor.encode(output).numel())
         return {"output": output}
 
     def encode_response(self, output):
         return {"output": output}
+
+    def teardown(self, devices):
+        self.experiment.finalize()
 
 
 if __name__ == "__main__":

--- a/src/litlogger/logger.py
+++ b/src/litlogger/logger.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Fabric/PyTorch Lightning logger that sends metrics and artifacts to Lightning.ai."""
+"""Deprecated compatibility logger for Lightning/Fabric integrations."""
 
 import logging
 import os
@@ -37,6 +37,17 @@ _ScanCheckpointsFn = Callable[[Any, dict[Any, Any]], list[tuple[float, str, floa
 
 log = logging.getLogger(__name__)
 
+
+def _warn_lightning_logger_deprecated() -> None:
+    warnings.warn(
+        "litlogger.LightningLogger is deprecated. Use lightning.pytorch.loggers.LitLogger "
+        "(or pytorch_lightning.loggers.LitLogger) for Lightning/Fabric integration, "
+        "or use litlogger.init() and the dict-style Experiment API for standalone usage.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+
 # Backwards compatibility -- use LitLogger lightning class if available
 # TODO: remove once pytorch lightning is released and we updated the code in frontend
 try:
@@ -56,7 +67,18 @@ except ImportError:
 if _base_classes:
 
     class LightningLogger(*_base_classes):  # type: ignore[misc]
-        pass
+        """Deprecated compatibility alias for the upstream Lightning LitLogger.
+
+        .. deprecated:: 2026.03.17
+
+           Use :class:`lightning:lightning.pytorch.loggers.LitLogger` for
+           Lightning/Fabric integration, or use :func:`litlogger.init.init` and the
+           dict-style ``Experiment`` API for standalone scripts.
+        """
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            _warn_lightning_logger_deprecated()
+            super().__init__(*args, **kwargs)
 
 else:
     _scan_checkpoints: _ScanCheckpointsFn
@@ -93,7 +115,14 @@ else:
         return cast(_F, rank_zero_experiment(fn))
 
     class LightningLogger(*_base_classes):  # type: ignore[misc, no-redef]
-        """Logger that streams metrics and artifacts to the Lightning.ai platform."""
+        """Deprecated compatibility logger for Lightning/Fabric integrations.
+
+        .. deprecated:: 2026.03.17
+
+           Use :class:`lightning:lightning.pytorch.loggers.LitLogger` for
+           Lightning/Fabric integration, or use :func:`litlogger.init.init` and the
+           dict-style ``Experiment`` API for standalone scripts.
+        """
 
         LOGGER_JOIN_CHAR = "-"
 
@@ -108,6 +137,12 @@ else:
             checkpoint_name: str | None = None,
         ) -> None:
             """Initialize the LightningLogger.
+
+            .. deprecated:: 2026.03.17
+
+               Use :class:`lightning:lightning.pytorch.loggers.LitLogger` for
+               Lightning/Fabric integration, or use :func:`litlogger.init` and
+               the dict-style ``Experiment`` API for standalone scripts.
 
             Args:
                 root_dir: Folder where logs and metadata are stored (default: ./lightning_logs).
@@ -144,6 +179,7 @@ else:
                 trainer.test(model, data_module)
 
             """
+            _warn_lightning_logger_deprecated()
             self._root_dir = os.fspath(root_dir or "./lightning_logs")
             self._name = name or _create_name()
             self._teamspace = teamspace


### PR DESCRIPTION
Deprecate `LightningLogger` in favor of `lightning.pytorch.loggers.LitLogger` or the new dict-based API