### PR TITLE
Remove trackers from BackgroundThread

### DIFF
--- a/src/litlogger/api/metrics_api.py
+++ b/src/litlogger/api/metrics_api.py
@@ -355,9 +355,14 @@ class MetricsApi:
         if not response.summaries_per_name:
             return {}
 
-        return {
-            name: s.summaries_per_id[metrics_stream_id].last_step for name, s in response.summaries_per_name.items()
-        }
+        result = {}
+        for name, s in response.summaries_per_name.items():
+            last_step = s.summaries_per_id[metrics_stream_id].last_step
+            try:
+                result[name] = int(last_step)
+            except (TypeError, ValueError):
+                pass
+        return result
 
     def get_trackers_from_metrics_store(self, metrics_store: Any) -> dict[str, MetricsTracker] | None:
         """Extract and convert trackers from a metrics store object.

--- a/src/litlogger/api/metrics_api.py
+++ b/src/litlogger/api/metrics_api.py
@@ -337,6 +337,28 @@ class MetricsApi:
             ),
         )
 
+    def get_last_steps(self, metrics_store_id: Any) -> dict[str, int] | None:
+        """Get the last logged step for each metric in the metrics store.
+
+        Args:
+            metrics_store_id: The metrics store ID.
+
+        Returns:
+            A dictionary mapping metric names to their last logged step, or None if no metrics are found
+        """
+        response = self.client.lit_logger_service_get_logger_metrics_summary(
+            project_id=self.teamspace_id,
+            ids=[metrics_store_id],
+        )
+
+        if not response.summaries_per_name:
+            return {}
+
+        return {
+            name: summaries_per_id[self.metrics_store_id].last_step
+            for name, summaries_per_id in response.summaries_per_name.items()
+        }
+
     def get_trackers_from_metrics_store(self, metrics_store: Any) -> dict[str, MetricsTracker] | None:
         """Extract and convert trackers from a metrics store object.
 

--- a/src/litlogger/api/metrics_api.py
+++ b/src/litlogger/api/metrics_api.py
@@ -356,8 +356,8 @@ class MetricsApi:
             return {}
 
         return {
-            name: summaries_per_id[metrics_stream_id].last_step
-            for name, summaries_per_id in response.summaries_per_name.items()
+            name: s.summaries_per_id[metrics_stream_id].last_step
+            for name, s in response.summaries_per_name.items()
         }
 
     def get_trackers_from_metrics_store(self, metrics_store: Any) -> dict[str, MetricsTracker] | None:

--- a/src/litlogger/api/metrics_api.py
+++ b/src/litlogger/api/metrics_api.py
@@ -337,17 +337,18 @@ class MetricsApi:
             ),
         )
 
-    def get_last_steps(self, metrics_store_id: Any) -> dict[str, int] | None:
+    def get_last_steps(self, teamspace_id: str, metrics_store_id: str) -> dict[str, int] | None:
         """Get the last logged step for each metric in the metrics store.
 
         Args:
+            teamspace_id: The teamspace ID.
             metrics_store_id: The metrics store ID.
 
         Returns:
             A dictionary mapping metric names to their last logged step, or None if no metrics are found
         """
         response = self.client.lit_logger_service_get_logger_metrics_summary(
-            project_id=self.teamspace_id,
+            project_id=teamspace_id,
             ids=[metrics_store_id],
         )
 

--- a/src/litlogger/api/metrics_api.py
+++ b/src/litlogger/api/metrics_api.py
@@ -356,8 +356,7 @@ class MetricsApi:
             return {}
 
         return {
-            name: s.summaries_per_id[metrics_stream_id].last_step
-            for name, s in response.summaries_per_name.items()
+            name: s.summaries_per_id[metrics_stream_id].last_step for name, s in response.summaries_per_name.items()
         }
 
     def get_trackers_from_metrics_store(self, metrics_store: Any) -> dict[str, MetricsTracker] | None:

--- a/src/litlogger/api/metrics_api.py
+++ b/src/litlogger/api/metrics_api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """API layer for metrics and experiment operations."""
 
+import contextlib
 import os
 from typing import Any
 
@@ -358,10 +359,8 @@ class MetricsApi:
         result = {}
         for name, s in response.summaries_per_name.items():
             last_step = s.summaries_per_id[metrics_stream_id].last_step
-            try:
+            with contextlib.suppress(TypeError, ValueError):
                 result[name] = int(last_step)
-            except (TypeError, ValueError):
-                pass
         return result
 
     def get_trackers_from_metrics_store(self, metrics_store: Any) -> dict[str, MetricsTracker] | None:

--- a/src/litlogger/api/metrics_api.py
+++ b/src/litlogger/api/metrics_api.py
@@ -337,26 +337,26 @@ class MetricsApi:
             ),
         )
 
-    def get_last_steps(self, teamspace_id: str, metrics_store_id: str) -> dict[str, int] | None:
+    def get_last_steps(self, teamspace_id: str, metrics_stream_id: str) -> dict[str, int] | None:
         """Get the last logged step for each metric in the metrics store.
 
         Args:
             teamspace_id: The teamspace ID.
-            metrics_store_id: The metrics store ID.
+            metrics_stream_id: The metrics stream ID.
 
         Returns:
             A dictionary mapping metric names to their last logged step, or None if no metrics are found
         """
         response = self.client.lit_logger_service_get_logger_metrics_summary(
             project_id=teamspace_id,
-            ids=[metrics_store_id],
+            ids=[metrics_stream_id],
         )
 
         if not response.summaries_per_name:
             return {}
 
         return {
-            name: summaries_per_id[self.metrics_store_id].last_step
+            name: summaries_per_id[metrics_stream_id].last_step
             for name, summaries_per_id in response.summaries_per_name.items()
         }
 

--- a/src/litlogger/background.py
+++ b/src/litlogger/background.py
@@ -130,6 +130,7 @@ class _BackgroundThread(Thread):
                             if value_obj.step is None:
                                 value_obj.step = self.last_steps.get(name, -1) + 1
                                 self.last_steps[name] = value_obj.step
+
                         # Merge with existing metrics for this name
                         if name in self.metrics:
                             self.metrics[name].values.extend(values.values)

--- a/src/litlogger/background.py
+++ b/src/litlogger/background.py
@@ -61,7 +61,7 @@ class _BackgroundThread(Thread):
         store_created_at: bool,
         rate_limiting_interval: int = 1,
         max_batch_size: int = 1000,
-        last_steps: dict[str, int] = {},
+        last_steps: dict[str, int] | None = None,
     ) -> None:
         super().__init__(daemon=True)
         self.teamspace_id = teamspace_id
@@ -76,7 +76,7 @@ class _BackgroundThread(Thread):
         self.done_event = done_event
         self.metrics: dict[str, Metrics] = {}
         self.exception: Exception | None = None
-        self.last_steps = last_steps
+        self.last_steps = last_steps or {}
 
         self.store_step = store_step
         self.store_created_at = store_created_at

--- a/src/litlogger/background.py
+++ b/src/litlogger/background.py
@@ -25,7 +25,7 @@ from time import sleep, time
 from lightning_sdk.lightning_cloud.openapi.rest import ApiException
 
 from litlogger.api.metrics_api import MetricsApi
-from litlogger.types import Metrics, MetricsTracker, PhaseType
+from litlogger.types import Metrics, PhaseType
 
 
 class _BackgroundThread(Thread):
@@ -61,7 +61,6 @@ class _BackgroundThread(Thread):
         store_created_at: bool,
         rate_limiting_interval: int = 1,
         max_batch_size: int = 1000,
-        trackers_init: dict[str, MetricsTracker] | None = None,
     ) -> None:
         super().__init__(daemon=True)
         self.teamspace_id = teamspace_id
@@ -79,8 +78,6 @@ class _BackgroundThread(Thread):
 
         self.store_step = store_step
         self.store_created_at = store_created_at
-
-        self.trackers: dict[str, MetricsTracker] = trackers_init if trackers_init is not None else {}
 
     def run(self) -> None:
         self._run()
@@ -127,7 +124,6 @@ class _BackgroundThread(Thread):
                 read_any = True
                 try:
                     for name, values in metrics.items():
-                        self._update_tracker(name, values)
                         # Merge with existing metrics for this name
                         if name in self.metrics:
                             self.metrics[name].values.extend(values.values)
@@ -170,45 +166,6 @@ class _BackgroundThread(Thread):
         self.last_time = time()
 
         self.metrics = {}
-
-    def _update_tracker(self, name: str, values: Metrics) -> None:
-        """Create or update the series tracker and refresh stats/counters from incoming values."""
-        # Create the tracker if it doesn't exist
-        if name not in self.trackers:
-            self.trackers[name] = MetricsTracker(name=name, num_rows=0)
-
-        tracker = self.trackers[name]
-
-        # Store the internal start step for this batch (used by BinaryFileWriter)
-        if not hasattr(values, "internal_start_step"):
-            values.internal_start_step = tracker.num_rows  # type: ignore[attr-defined]
-
-        # Increment the number of rows
-        for value_obj in values.values:
-            # Augment with step from tracker if not provided
-            if value_obj.step is None:
-                value_obj.step = tracker.num_rows
-
-            value = float(value_obj.value)
-
-            if tracker.started_at is None and self.store_created_at and value_obj.created_at:
-                tracker.started_at = value_obj.created_at
-
-            if tracker.min_value is None or (tracker.min_value is not None and value < tracker.min_value):
-                tracker.min_value = value
-                tracker.min_index = tracker.num_rows
-
-            if tracker.max_value is None or (tracker.max_value is not None and value > tracker.max_value):
-                tracker.max_value = value
-                tracker.max_index = tracker.num_rows
-
-            tracker.last_index = tracker.num_rows
-            tracker.last_value = value
-
-            if self.store_created_at and value_obj.created_at:
-                tracker.updated_at = value_obj.created_at
-
-            tracker.num_rows += 1
 
     def _send_metrics(self, metrics: list[Metrics]) -> None:
         """Send metrics to the API, chunking into batches of max_batch_size values per request.
@@ -275,5 +232,4 @@ class _BackgroundThread(Thread):
             metrics_store_id=self.metrics_store_id,
             persisted=True,
             phase=PhaseType.COMPLETED,
-            trackers=self.trackers,
         )

--- a/src/litlogger/background.py
+++ b/src/litlogger/background.py
@@ -61,6 +61,7 @@ class _BackgroundThread(Thread):
         store_created_at: bool,
         rate_limiting_interval: int = 1,
         max_batch_size: int = 1000,
+        last_steps: dict[str, int] = {},
     ) -> None:
         super().__init__(daemon=True)
         self.teamspace_id = teamspace_id
@@ -75,6 +76,7 @@ class _BackgroundThread(Thread):
         self.done_event = done_event
         self.metrics: dict[str, Metrics] = {}
         self.exception: Exception | None = None
+        self.last_steps = last_steps
 
         self.store_step = store_step
         self.store_created_at = store_created_at
@@ -124,6 +126,10 @@ class _BackgroundThread(Thread):
                 read_any = True
                 try:
                     for name, values in metrics.items():
+                        for value_obj in values.values:
+                            if value_obj.step is None:
+                                value_obj.step = self.last_steps.get(name, -1) + 1
+                                self.last_steps[name] = value_obj.step
                         # Merge with existing metrics for this name
                         if name in self.metrics:
                             self.metrics[name].values.extend(values.values)

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -170,7 +170,7 @@ class Experiment(LegacyExperiment):
             store_created_at=bool(store_created_at),
             rate_limiting_interval=rate_limiting_interval,
             max_batch_size=max_batch_size,
-            last_steps=self._metrics_api.get_last_steps(self._metrics_store.id) or {},
+            last_steps=self._metrics_api.get_last_steps(self._teamspace.id, self._metrics_store.id),
         )
 
         self._manager.start()

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -170,7 +170,6 @@ class Experiment(LegacyExperiment):
             store_created_at=bool(store_created_at),
             rate_limiting_interval=rate_limiting_interval,
             max_batch_size=max_batch_size,
-            trackers_init=self._metrics_api.get_trackers_from_metrics_store(self._metrics_store),
         )
 
         self._manager.start()

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -170,6 +170,7 @@ class Experiment(LegacyExperiment):
             store_created_at=bool(store_created_at),
             rate_limiting_interval=rate_limiting_interval,
             max_batch_size=max_batch_size,
+            last_steps=self._metrics_api.get_last_steps(self._metrics_store.id) or {},
         )
 
         self._manager.start()

--- a/tests/unittests/test_background_thread.py
+++ b/tests/unittests/test_background_thread.py
@@ -66,6 +66,50 @@ class TestBackgroundThreadInit:
         assert manager.max_batch_size == 1000
 
 
+class TestBackgroundThreadLastSteps:
+    """Test _BackgroundThread step resumption from last_steps."""
+
+    def _make_manager(self, last_steps=None):
+        mock_queue = Mock()
+        mock_queue.get.side_effect = [
+            {"loss": Metrics(name="loss", values=[MetricValue(value=0.5)])},
+            {"loss": Metrics(name="loss", values=[MetricValue(value=0.4)])},
+            {"loss": Metrics(name="loss", values=[MetricValue(value=0.3)])},
+            queue.Empty(),
+        ]
+        return _BackgroundThread(
+            teamspace_id="test",
+            metrics_store_id="test",
+            metrics_api=Mock(),
+            metrics_queue=mock_queue,
+            is_ready_event=Event(),
+            stop_event=Event(),
+            done_event=Event(),
+            store_step=True,
+            store_created_at=False,
+            rate_limiting_interval=100,
+            last_steps=last_steps,
+        )
+
+    def test_steps_start_at_zero_when_last_steps_is_none(self):
+        manager = self._make_manager(last_steps=None)
+        manager.step()
+        steps = [v.step for v in manager.metrics["loss"].values]
+        assert steps == [0, 1, 2]
+
+    def test_steps_start_at_zero_when_last_steps_is_empty(self):
+        manager = self._make_manager(last_steps={})
+        manager.step()
+        steps = [v.step for v in manager.metrics["loss"].values]
+        assert steps == [0, 1, 2]
+
+    def test_steps_resume_from_last_steps_when_provided(self):
+        manager = self._make_manager(last_steps={"loss": 5})
+        manager.step()
+        steps = [v.step for v in manager.metrics["loss"].values]
+        assert steps == [6, 7, 8]
+
+
 class TestBackgroundThreadStepBatching:
     """Test _BackgroundThread.step batching behavior."""
 

--- a/tests/unittests/test_background_thread.py
+++ b/tests/unittests/test_background_thread.py
@@ -1,66 +1,15 @@
 import queue
-from collections import defaultdict
-from datetime import datetime
 from multiprocessing import Event, Queue
 from unittest.mock import Mock, patch
 
 import pytest
 from lightning_sdk.lightning_cloud.openapi.rest import ApiException
 from litlogger.background import _BackgroundThread
-from litlogger.types import Metrics, MetricsTracker, MetricValue, PhaseType
+from litlogger.types import Metrics, MetricValue, PhaseType
 
 
 class TestBackgroundThreadInit:
     """Test _BackgroundThread initialization."""
-
-    def test_init_with_trackers_init(self):
-        """Test initialization with existing trackers."""
-        mock_metrics_api = Mock()
-        mock_queue = Queue()
-        is_ready_event = Event()
-        stop_event = Event()
-        done_event = Event()
-
-        initial_trackers = {
-            "loss": MetricsTracker(name="loss", num_rows=100, min_value=0.1, max_value=1.0),
-            "accuracy": MetricsTracker(name="accuracy", num_rows=50, min_value=0.8, max_value=0.99),
-        }
-
-        manager = _BackgroundThread(
-            teamspace_id="test_teamspace",
-            metrics_store_id="test_stream",
-            metrics_api=mock_metrics_api,
-            metrics_queue=mock_queue,
-            is_ready_event=is_ready_event,
-            stop_event=stop_event,
-            done_event=done_event,
-            store_step=True,
-            store_created_at=False,
-            trackers_init=initial_trackers,
-        )
-
-        # Verify trackers were initialized from trackers_init
-        assert "loss" in manager.trackers
-        assert "accuracy" in manager.trackers
-        assert manager.trackers["loss"].num_rows == 100
-        assert manager.trackers["accuracy"].num_rows == 50
-
-    def test_init_with_trackers_init_none(self):
-        """Test initialization with trackers_init=None creates empty trackers."""
-        manager = _BackgroundThread(
-            teamspace_id="test",
-            metrics_store_id="test",
-            metrics_api=Mock(),
-            metrics_queue=Queue(),
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=False,
-            trackers_init=None,
-        )
-
-        assert manager.trackers == {}
 
     def test_init_with_all_parameters(self):
         """Test initialization with all required parameters."""
@@ -96,7 +45,6 @@ class TestBackgroundThreadInit:
         assert manager.store_step is True
         assert manager.store_created_at is False
         assert manager.metrics == {}
-        assert manager.trackers == {}
         assert manager.exception is None
         assert manager.daemon is True
 
@@ -168,35 +116,6 @@ class TestBackgroundThreadStepBatching:
         assert result is False
         assert len(manager.metrics) == 0
 
-    def test_step_updates_tracker(self):
-        """Test that step calls _update_tracker for each metric."""
-        mock_queue = Mock()
-        metrics_data = {
-            "loss": Metrics(name="loss", values=[MetricValue(value=0.5)]),
-            "acc": Metrics(name="acc", values=[MetricValue(value=0.9)]),
-        }
-        mock_queue.get.side_effect = [metrics_data, queue.Empty()]
-
-        manager = _BackgroundThread(
-            teamspace_id="test",
-            metrics_store_id="test",
-            metrics_api=Mock(),
-            metrics_queue=mock_queue,
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=False,
-            rate_limiting_interval=100,  # High value to prevent time-based send
-        )
-
-        with patch.object(manager, "_update_tracker") as mock_update:
-            manager.step()
-
-            assert mock_update.call_count == 2
-            mock_update.assert_any_call("loss", metrics_data["loss"])
-            mock_update.assert_any_call("acc", metrics_data["acc"])
-
     def test_step_sends_when_max_batch_reached(self):
         """Test that step sends when max_batch_size is reached."""
         mock_queue = Mock()
@@ -251,288 +170,6 @@ class TestBackgroundThreadStepBatching:
         assert manager.metrics["loss"].values[1].value == 0.3
 
 
-class TestBackgroundThreadStepAugmentation:
-    """Test step augmentation from trackers when metrics don't have steps."""
-
-    def test_augments_step_when_none(self):
-        """Test that metrics without steps get augmented with tracker num_rows."""
-        manager = _BackgroundThread(
-            teamspace_id="test",
-            metrics_store_id="test",
-            metrics_api=Mock(),
-            metrics_queue=Mock(),
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=False,
-        )
-
-        # Create values without steps
-        values = Metrics(
-            name="loss",
-            values=[
-                MetricValue(value=0.5, step=None),
-                MetricValue(value=0.4, step=None),
-                MetricValue(value=0.3, step=None),
-            ],
-        )
-
-        manager._update_tracker("loss", values)
-
-        # Verify steps were augmented sequentially
-        assert values.values[0].step == 0
-        assert values.values[1].step == 1
-        assert values.values[2].step == 2
-
-    def test_preserves_explicit_steps(self):
-        """Test that metrics with explicit steps are not modified."""
-        manager = _BackgroundThread(
-            teamspace_id="test",
-            metrics_store_id="test",
-            metrics_api=Mock(),
-            metrics_queue=Mock(),
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=False,
-        )
-
-        # Create values with explicit steps
-        values = Metrics(
-            name="loss",
-            values=[
-                MetricValue(value=0.5, step=10),
-                MetricValue(value=0.4, step=20),
-                MetricValue(value=0.3, step=30),
-            ],
-        )
-
-        manager._update_tracker("loss", values)
-
-        # Verify explicit steps were preserved
-        assert values.values[0].step == 10
-        assert values.values[1].step == 20
-        assert values.values[2].step == 30
-
-    def test_augments_step_from_initialized_tracker(self):
-        """Test that step augmentation continues from initialized tracker num_rows."""
-        initial_trackers = {
-            "loss": MetricsTracker(name="loss", num_rows=100),
-        }
-
-        manager = _BackgroundThread(
-            teamspace_id="test",
-            metrics_store_id="test",
-            metrics_api=Mock(),
-            metrics_queue=Mock(),
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=False,
-            trackers_init=initial_trackers,
-        )
-
-        # Create values without steps
-        values = Metrics(
-            name="loss",
-            values=[
-                MetricValue(value=0.5, step=None),
-                MetricValue(value=0.4, step=None),
-            ],
-        )
-
-        manager._update_tracker("loss", values)
-
-        # Verify steps continue from tracker's num_rows (100)
-        assert values.values[0].step == 100
-        assert values.values[1].step == 101
-
-    def test_mixed_explicit_and_none_steps(self):
-        """Test handling of mixed explicit and None steps."""
-        manager = _BackgroundThread(
-            teamspace_id="test",
-            metrics_store_id="test",
-            metrics_api=Mock(),
-            metrics_queue=Mock(),
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=False,
-        )
-
-        # Create values with mixed steps
-        values = Metrics(
-            name="loss",
-            values=[
-                MetricValue(value=0.5, step=None),  # Should get 0
-                MetricValue(value=0.4, step=50),  # Should stay 50
-                MetricValue(value=0.3, step=None),  # Should get 2
-            ],
-        )
-
-        manager._update_tracker("loss", values)
-
-        # Verify correct step handling
-        assert values.values[0].step == 0
-        assert values.values[1].step == 50
-        assert values.values[2].step == 2
-
-
-class TestBackgroundThreadUpdateTracker:
-    """Test _BackgroundThread._update_tracker method."""
-
-    def test_create_new_tracker(self):
-        """Test creating a new tracker for a metric."""
-        manager = _BackgroundThread(
-            teamspace_id="test",
-            metrics_store_id="test",
-            metrics_api=Mock(),
-            metrics_queue=Mock(),
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=False,
-        )
-
-        values = Mock()
-        values.values = [MetricValue(value=1.0, step=0)]
-
-        manager._update_tracker("new_metric", values)
-
-        assert "new_metric" in manager.trackers
-        assert manager.trackers["new_metric"].name == "new_metric"
-        assert manager.trackers["new_metric"].num_rows == 1
-
-    def test_update_existing_tracker(self):
-        """Test updating an existing tracker."""
-        manager = _BackgroundThread(
-            teamspace_id="test",
-            metrics_store_id="test",
-            metrics_api=Mock(),
-            metrics_queue=Mock(),
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=False,
-        )
-
-        # Create initial tracker
-        values1 = Mock()
-        values1.values = [MetricValue(value=1.0, step=0)]
-        manager._update_tracker("metric", values1)
-
-        # Update with new values
-        values2 = Mock()
-        values2.values = [MetricValue(value=2.0, step=1)]
-        manager._update_tracker("metric", values2)
-
-        assert manager.trackers["metric"].num_rows == 2
-
-    def test_tracker_min_max_values(self):
-        """Test that tracker correctly tracks min and max values."""
-        manager = _BackgroundThread(
-            teamspace_id="test",
-            metrics_store_id="test",
-            metrics_api=Mock(),
-            metrics_queue=Mock(),
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=False,
-        )
-
-        values = Mock()
-        values.values = [
-            MetricValue(value=5.0, step=0),
-            MetricValue(value=2.0, step=1),
-            MetricValue(value=8.0, step=2),
-            MetricValue(value=3.0, step=3),
-        ]
-
-        manager._update_tracker("metric", values)
-
-        tracker = manager.trackers["metric"]
-        assert tracker.min_value == 2.0
-        assert tracker.min_index == 1
-        assert tracker.max_value == 8.0
-        assert tracker.max_index == 2
-        assert tracker.last_value == 3.0
-        assert tracker.last_index == 3
-
-    def test_tracker_internal_start_step_assignment(self):
-        """Test internal_start_step is correctly assigned across batches."""
-        manager = _BackgroundThread(
-            teamspace_id="test",
-            metrics_store_id="test",
-            metrics_api=Mock(),
-            metrics_queue=Mock(),
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=False,
-        )
-
-        # Create test values for two metrics with multiple batches
-        metric_names = ("metric1", "metric2")
-        values = defaultdict(list)
-
-        for _ in range(2):
-            for metric_name in metric_names:
-                for _ in range(2):
-                    batch = Metrics(name=metric_name, values=[MetricValue(value=float(i), step=i) for i in range(3)])
-                    values[metric_name].append(batch)
-
-        # Update trackers sequentially
-        for metric_name in metric_names:
-            for batch in values[metric_name]:
-                manager._update_tracker(metric_name, batch)
-
-        # Verify internal steps are correctly assigned
-        for metric_name in metric_names:
-            assert values[metric_name][0].internal_start_step == 0
-            assert values[metric_name][1].internal_start_step == 3
-            assert values[metric_name][2].internal_start_step == 6
-            assert values[metric_name][3].internal_start_step == 9
-            assert manager.trackers[metric_name].num_rows == 12
-
-    def test_tracker_with_created_at_timestamps(self):
-        """Test tracker handles created_at timestamps when store_created_at is True."""
-        manager = _BackgroundThread(
-            teamspace_id="test",
-            metrics_store_id="test",
-            metrics_api=Mock(),
-            metrics_queue=Mock(),
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=True,
-        )
-
-        timestamp1 = "2024-03-14T12:00:00.000000+00:00"
-        timestamp2 = "2024-03-14T12:01:00.000000+00:00"
-
-        values = Mock()
-        values.values = [
-            MetricValue(value=1.0, step=0, created_at=timestamp1),
-            MetricValue(value=2.0, step=1, created_at=timestamp2),
-        ]
-
-        manager._update_tracker("metric", values)
-
-        tracker = manager.trackers["metric"]
-        assert tracker.started_at is not None
-        assert tracker.updated_at is not None
-
-
 class TestBackgroundThreadSend:
     """Test _BackgroundThread._send method."""
 
@@ -573,13 +210,10 @@ class TestBackgroundThreadSend:
             store_created_at=False,
         )
 
-        metrics_data = {"loss": Metrics(name="loss", values=[MetricValue(value=0.5)])}
-        manager.metrics = metrics_data
-        manager.trackers = {"loss": MetricsTracker(name="loss", num_rows=1)}
+        manager.metrics = {"loss": Metrics(name="loss", values=[MetricValue(value=0.5)])}
 
         manager._send()
 
-        # Verify API was called
         assert mock_metrics_api.append_experiment_metrics.called
         assert manager.metrics == {}
 
@@ -601,7 +235,6 @@ class TestBackgroundThreadSend:
         )
 
         manager.metrics = {"loss": Metrics(name="loss", values=[MetricValue(value=0.5)])}
-        manager.trackers = {"loss": MetricsTracker(name="loss", num_rows=1)}
 
         with pytest.raises(Exception, match="The metrics stream has been deleted"):
             manager._send()
@@ -626,7 +259,6 @@ class TestBackgroundThreadSend:
         )
 
         manager.metrics = {"loss": Metrics(name="loss", values=[MetricValue(value=0.5)])}
-        manager.trackers = {"loss": MetricsTracker(name="loss", num_rows=1)}
 
         with pytest.raises(ApiException):
             manager._send()
@@ -807,8 +439,8 @@ class TestBackgroundThreadStep:
 class TestBackgroundThreadInformDone:
     """Test _BackgroundThread.inform_done method."""
 
-    def test_inform_done_without_timestamps(self):
-        """Test inform_done updates stream without timestamp conversion."""
+    def test_inform_done(self):
+        """Test inform_done updates stream with COMPLETED phase."""
         mock_metrics_api = Mock()
 
         manager = _BackgroundThread(
@@ -823,15 +455,6 @@ class TestBackgroundThreadInformDone:
             store_created_at=False,
         )
 
-        manager.trackers = {
-            "loss": MetricsTracker(
-                name="loss",
-                num_rows=10,
-                min_value=0.1,
-                max_value=1.0,
-            )
-        }
-
         manager.inform_done()
 
         mock_metrics_api.update_experiment_metrics.assert_called_once()
@@ -840,46 +463,6 @@ class TestBackgroundThreadInformDone:
         assert call_args.kwargs["metrics_store_id"] == "test_stream"
         assert call_args.kwargs["persisted"] is True
         assert call_args.kwargs["phase"] == PhaseType.COMPLETED
-
-    def test_inform_done_with_timestamps(self):
-        """Test inform_done converts timestamps when store_created_at is True."""
-        mock_metrics_api = Mock()
-
-        manager = _BackgroundThread(
-            teamspace_id="test_teamspace",
-            metrics_store_id="test_stream",
-            metrics_api=mock_metrics_api,
-            metrics_queue=Mock(),
-            is_ready_event=Event(),
-            stop_event=Event(),
-            done_event=Event(),
-            store_step=True,
-            store_created_at=True,
-        )
-
-        # Use actual datetime objects (not timestamps)
-        started_datetime = datetime(2024, 3, 14, 12, 0, 0)
-        updated_datetime = datetime(2024, 3, 14, 12, 5, 0)
-
-        manager.trackers = {
-            "loss": MetricsTracker(
-                name="loss",
-                num_rows=10,
-                started_at=started_datetime,
-                updated_at=updated_datetime,
-            )
-        }
-
-        manager.inform_done()
-
-        # Verify datetime objects are preserved (not converted to timestamps or strings in user-facing code)
-        tracker = manager.trackers["loss"]
-        assert isinstance(tracker.started_at, datetime)
-        assert isinstance(tracker.updated_at, datetime)
-        assert tracker.started_at == started_datetime
-        assert tracker.updated_at == updated_datetime
-
-        mock_metrics_api.update_experiment_metrics.assert_called_once()
 
 
 class TestBackgroundThreadRun:
@@ -966,7 +549,7 @@ class TestBackgroundThreadIntegration:
     """Integration tests for _BackgroundThread."""
 
     def test_full_workflow_with_metrics(self):
-        """Test complete workflow from queue to upload."""
+        """Test complete workflow from queue to send."""
         mock_metrics_api = Mock()
         metrics_queue = Queue()
         stop_event = Event()


### PR DESCRIPTION
We no longer need to maintain the trackers here because:
1. we're no longer writing them to the .litbin files,
2. they are updated from the backend.

The only thing they are actually used for is resuming experiments and keeping track of the last step, but can use the new `lit_logger_service_get_logger_metrics_summary` endpoint to do that now, so let's just keep track of the last step per metric rather than the full tracker information.