### PR TITLE
Fix missing cross-references in docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -116,9 +116,3 @@ Deprecated compatibility alias for Lightning/Fabric integration. Prefer
 .. autoclass:: LightningLogger
    :members:
    :show-inheritance:
-
-.. autoattribute:: LightningLogger.url
-
-.. automethod:: LightningLogger.log_file
-
-.. automethod:: LightningLogger.log_model_artifact

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -121,6 +121,4 @@ Deprecated compatibility alias for Lightning/Fabric integration. Prefer
 
 .. automethod:: LightningLogger.log_file
 
-.. automethod:: LightningLogger.log_media
-
 .. automethod:: LightningLogger.log_model_artifact

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -116,3 +116,11 @@ Deprecated compatibility alias for Lightning/Fabric integration. Prefer
 .. autoclass:: LightningLogger
    :members:
    :show-inheritance:
+
+.. autoattribute:: LightningLogger.url
+
+.. automethod:: LightningLogger.log_file
+
+.. automethod:: LightningLogger.log_media
+
+.. automethod:: LightningLogger.log_model_artifact

--- a/docs/source/guide/artifacts.rst
+++ b/docs/source/guide/artifacts.rst
@@ -31,7 +31,7 @@ Log and Retrieve Files
 ======================
 
 The legacy helper API is still supported for explicit file upload/download
-workflows:
+workflows through :func:`~litlogger.log_file` and :func:`~litlogger.get_file`:
 
 .. code-block:: python
 
@@ -50,8 +50,8 @@ workflows:
 Logging Multiple Files
 ======================
 
-:meth:`litlogger.log_files() <litlogger.experiment.Experiment.log_files>` uploads
-a list of files in parallel for better throughput:
+:meth:`~litlogger.experiment.Experiment.log_files` uploads a list of files in
+parallel for better throughput:
 
 .. code-block:: python
 
@@ -65,7 +65,8 @@ Log and Retrieve Models
 =======================
 
 LitLogger integrates with ``litmodels`` for storing and loading model objects.
-The legacy helper API still supports direct model-object logging:
+The legacy helper API still supports direct model-object logging through
+:func:`~litlogger.log_model` and :func:`~litlogger.get_model`:
 
 .. code-block:: python
 
@@ -90,7 +91,7 @@ Logging Model Files
 ===================
 
 If you already have saved model files on disk, use
-:meth:`litlogger.log_model_artifact() <litlogger.experiment.Experiment.log_model_artifact>`:
+:meth:`~litlogger.experiment.Experiment.log_model_artifact`:
 
 .. code-block:: python
 
@@ -98,7 +99,8 @@ If you already have saved model files on disk, use
    exp.log_model_artifact("checkpoints/epoch_10.ckpt", version="epoch-10")
    exp.log_model_artifact("model_export/", version="export-v2")
 
-Download model artifacts back:
+Download model artifacts back with
+:meth:`~litlogger.experiment.Experiment.get_model_artifact`:
 
 .. code-block:: python
 

--- a/docs/source/guide/examples.rst
+++ b/docs/source/guide/examples.rst
@@ -6,8 +6,9 @@ Examples
 Standalone
 ==========
 
-A standalone training script using the module-level API to log metrics,
-metadata, and files.
+A standalone training script using the module-level API through
+:func:`~litlogger.log_metrics`, :func:`~litlogger.log_metadata`, and
+:func:`~litlogger.log_file`.
 
 .. literalinclude:: ../../../examples/standalone_usage.py
    :language: python
@@ -17,8 +18,9 @@ metadata, and files.
 Files, Media, and Models
 ========================
 
-A dict-style example showing static uploads, file and text series, image logging,
-and the new ``Model`` API for artifacts, objects, and checkpoint series.
+A dict-style example showing static uploads, file and text series, image
+logging, and the :class:`~litlogger.media.Model` API for artifacts, objects,
+and checkpoint series.
 
 .. literalinclude:: ../../../examples/file_media_model_usage.py
    :language: python

--- a/docs/source/guide/lightning.rst
+++ b/docs/source/guide/lightning.rst
@@ -89,11 +89,8 @@ logger:
 Logging Files and Models
 ========================
 
-The logger also exposes
-:meth:`~litlogger.logger.LightningLogger.log_file`,
-:meth:`~litlogger.logger.LightningLogger.log_model_artifact`, and matching
-helpers on :class:`lightning:lightning.pytorch.loggers.LitLogger` for file and
-model logging:
+The logger also exposes matching file and model logging helpers on
+:class:`lightning:lightning.pytorch.loggers.LitLogger`:
 
 .. code-block:: python
 
@@ -106,8 +103,8 @@ For media uploads in Lightning workflows, use the standalone
 Accessing the Experiment URL
 ============================
 
-Use :attr:`~litlogger.logger.LightningLogger.url` to retrieve the run URL from
-the logger instance.
+Use the logger's ``url`` property to retrieve the run URL from the logger
+instance.
 
 .. code-block:: python
 

--- a/docs/source/guide/lightning.rst
+++ b/docs/source/guide/lightning.rst
@@ -89,7 +89,11 @@ logger:
 Logging Files, Media, and Models
 ================================
 
-The logger also exposes helper methods for artifact, media, and model logging:
+The logger also exposes
+:meth:`~litlogger.logger.LightningLogger.log_file`,
+:meth:`~litlogger.logger.LightningLogger.log_media`, and
+:meth:`~litlogger.logger.LightningLogger.log_model_artifact` for artifact,
+media, and model logging:
 
 .. code-block:: python
 
@@ -99,6 +103,9 @@ The logger also exposes helper methods for artifact, media, and model logging:
 
 Accessing the Experiment URL
 ============================
+
+Use :attr:`~litlogger.logger.LightningLogger.url` to retrieve the run URL from
+the logger instance.
 
 .. code-block:: python
 

--- a/docs/source/guide/lightning.rst
+++ b/docs/source/guide/lightning.rst
@@ -86,20 +86,22 @@ logger:
        loss = train_step()
        fabric.log("train_loss", loss, step=step)
 
-Logging Files, Media, and Models
-================================
+Logging Files and Models
+========================
 
 The logger also exposes
 :meth:`~litlogger.logger.LightningLogger.log_file`,
-:meth:`~litlogger.logger.LightningLogger.log_media`, and
-:meth:`~litlogger.logger.LightningLogger.log_model_artifact` for artifact,
-media, and model logging:
+:meth:`~litlogger.logger.LightningLogger.log_model_artifact`, and matching
+helpers on :class:`lightning:lightning.pytorch.loggers.LitLogger` for file and
+model logging:
 
 .. code-block:: python
 
    trainer.logger.log_file("config.yaml")
-   trainer.logger.log_media("sample", "output.png", step=epoch)
    trainer.logger.log_model_artifact("checkpoints/best.ckpt", version="best")
+
+For media uploads in Lightning workflows, use the standalone
+:class:`~litlogger.experiment.Experiment` API directly.
 
 Accessing the Experiment URL
 ============================

--- a/docs/source/guide/media.rst
+++ b/docs/source/guide/media.rst
@@ -81,19 +81,8 @@ Deprecated Compatibility Logger
 
 :class:`~litlogger.logger.LightningLogger` is deprecated. For Lightning or
 Fabric integrations, prefer
-:class:`lightning:lightning.pytorch.loggers.LitLogger` and use
-:meth:`~litlogger.logger.LightningLogger.log_media` from callbacks or your
-LightningModule.
-
-.. code-block:: python
-
-   from lightning.pytorch.loggers import LitLogger
-
-   logger = LitLogger(name="vision-run")
-
-   logger.log_media(
-       "val_sample",
-       "val_output.png",
-       step=trainer.global_step,
-       caption="Validation sample",
-   )
+:class:`lightning:lightning.pytorch.loggers.LitLogger` for metrics, files, and
+model artifacts. For media uploads, use the standalone
+:class:`~litlogger.experiment.Experiment` API directly; the upstream
+:class:`lightning:lightning.pytorch.loggers.LitLogger` does not expose a
+``log_media`` helper.

--- a/docs/source/guide/media.rst
+++ b/docs/source/guide/media.rst
@@ -25,8 +25,9 @@ New Dict-Style API
 Legacy Helper API
 =================
 
-The legacy helper method remains available for existing code, but new
-standalone code should prefer the dict-style wrappers.
+The legacy helper method :meth:`~litlogger.experiment.Experiment.log_media`
+remains available for existing code, but new standalone code should prefer the
+dict-style wrappers.
 
 Logging Images
 ==============
@@ -80,8 +81,9 @@ Deprecated Compatibility Logger
 
 :class:`~litlogger.logger.LightningLogger` is deprecated. For Lightning or
 Fabric integrations, prefer
-:class:`lightning:lightning.pytorch.loggers.LitLogger` and use its media
-helpers from callbacks or your LightningModule.
+:class:`lightning:lightning.pytorch.loggers.LitLogger` and use
+:meth:`~litlogger.logger.LightningLogger.log_media` from callbacks or your
+LightningModule.
 
 .. code-block:: python
 

--- a/docs/source/guide/standalone.rst
+++ b/docs/source/guide/standalone.rst
@@ -35,10 +35,12 @@ Recommended New API
 The new standalone API covers:
 
 - metadata through ``experiment["key"] = "value"``
-- metrics through ``append`` and ``extend``
+- metrics through :meth:`~litlogger.series.Series.append` and
+  :meth:`~litlogger.series.Series.extend`
 - artifacts, media, and models through file-like wrappers
-- retrieval through ``experiment.metadata``, ``experiment.metrics``, and
-  ``experiment.artifacts``
+- retrieval through :attr:`~litlogger.experiment.Experiment.metadata`,
+  :attr:`~litlogger.experiment.Experiment.metrics`, and
+  :attr:`~litlogger.experiment.Experiment.artifacts`
 
 Metric Logging
 ==============
@@ -88,6 +90,11 @@ Initializing with the same name reconnects to the same experiment.
 Runtime Views
 =============
 
+Use :attr:`~litlogger.experiment.Experiment.metadata`,
+:attr:`~litlogger.experiment.Experiment.metrics`,
+:attr:`~litlogger.experiment.Experiment.artifacts`, and
+:attr:`~litlogger.experiment.Experiment.url` to inspect the current run state.
+
 .. code-block:: python
 
    print(experiment.metadata)
@@ -98,7 +105,9 @@ Runtime Views
 Legacy Module-Level API
 =======================
 
-The older module-level API is still available for compatibility:
+The older module-level API is still available for compatibility through
+:func:`~litlogger.log_metrics`, :func:`~litlogger.log_file`,
+:func:`~litlogger.log_metadata`, and :func:`~litlogger.finalize`:
 
 .. code-block:: python
 

--- a/docs/source/guide/workflows.rst
+++ b/docs/source/guide/workflows.rst
@@ -1,3 +1,4 @@
+
 #########
 Workflows
 #########
@@ -13,7 +14,8 @@ Recommended for new code.
 - initialize with :func:`litlogger.init.init`
 - work with the returned :class:`~litlogger.experiment.Experiment`
 - log metadata with ``experiment["key"] = "value"``
-- log metrics with ``experiment["key"].append(...)`` and ``extend(...)``
+- log metrics with :meth:`~litlogger.series.Series.append` and
+  :meth:`~litlogger.series.Series.extend` on ``experiment["key"]``
 - log files, media, and models with the file-like wrappers
 
 Legacy Module-Level API
@@ -22,11 +24,11 @@ Legacy Module-Level API
 Supported for existing standalone scripts, but the dict-style API is the main
 user-facing API going forward.
 
-- ``litlogger.log_metrics(...)``
-- ``litlogger.log_file(...)``
-- ``litlogger.log_model(...)``
-- ``litlogger.log_model_artifact(...)``
-- ``litlogger.log_metadata(...)``
+- :func:`~litlogger.log_metrics`
+- :func:`~litlogger.log_file`
+- :func:`~litlogger.log_model`
+- :func:`~litlogger.log_model_artifact`
+- :func:`~litlogger.log_metadata`
 
 Lightning and Fabric
 ====================
@@ -49,7 +51,9 @@ Resume and Retrieval
 ====================
 
 Re-initialize with the same experiment name to continue logging or inspect
-existing metadata, metrics, artifacts, and media.
+existing :attr:`~litlogger.experiment.Experiment.metadata`,
+:attr:`~litlogger.experiment.Experiment.metrics`,
+:attr:`~litlogger.experiment.Experiment.artifacts`, and media.
 
 End-to-End Log and Fetch
 ========================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,11 +35,16 @@ Supported Workflows
 
 LitLogger currently supports these main workflows:
 
-- standalone logging with the dict-style ``Experiment`` API
+- standalone logging with the dict-style
+  :class:`~litlogger.experiment.Experiment` API
 - legacy module-level logging helpers for existing scripts
-- Lightning and Fabric integration through upstream ``LitLogger`` classes
-- file, image, text, and model logging through dedicated wrappers
-- experiment resume and later retrieval by name
+- Lightning and Fabric integration through upstream
+  :class:`lightning:lightning.pytorch.loggers.LitLogger`
+- file, image, text, and model logging through
+  :class:`~litlogger.media.File`, :class:`~litlogger.media.Image`,
+  :class:`~litlogger.media.Text`, and :class:`~litlogger.media.Model`
+- experiment resume and later retrieval by name through
+  :func:`litlogger.init.init`
 - inference logging from a LitServe endpoint
 
 Quick Example

--- a/docs/source/tutorials/file_media_model.rst
+++ b/docs/source/tutorials/file_media_model.rst
@@ -70,13 +70,9 @@ Use :class:`~litlogger.media.Model` for model objects or saved model files.
 Unlike files, images, and text entries, logged models are registered in the
 ``Weights`` tab of Lightning AI rather than the experiment's ``Experiments``
 tab. For background, see the `Lightning model registry docs <https://lightning.ai/docs/overview/model-registry>`_.
-
-Current Recovery Note
-=====================
-
-Within the current process, uploaded ``Model`` values are rebound with download
-or load behavior. Resumed experiment recovery for models still needs dedicated
-backend support.
+Within the current process, uploaded :class:`~litlogger.media.Model` values are
+rebound with download or load behavior. Resumed experiment recovery for models
+still needs dedicated backend support.
 
 Finalize
 ========

--- a/docs/source/tutorials/lightning.rst
+++ b/docs/source/tutorials/lightning.rst
@@ -64,10 +64,7 @@ Enable automatic checkpoint uploads with ``log_model=True``.
 Files and Models
 ================
 
-The logger also exposes
-:meth:`~litlogger.logger.LightningLogger.log_file` and
-:meth:`~litlogger.logger.LightningLogger.log_model_artifact` for file and model
-logging:
+The logger also exposes file and model logging helpers:
 
 .. code-block:: python
 

--- a/docs/source/tutorials/lightning.rst
+++ b/docs/source/tutorials/lightning.rst
@@ -61,18 +61,23 @@ Enable automatic checkpoint uploads with ``log_model=True``.
        callbacks=[checkpoint_callback],
    )
 
-Files and Media
-===============
+Files and Models
+================
 
 The logger also exposes
 :meth:`~litlogger.logger.LightningLogger.log_file` and
-:meth:`~litlogger.logger.LightningLogger.log_media` for artifact and media
+:meth:`~litlogger.logger.LightningLogger.log_model_artifact` for file and model
 logging:
 
 .. code-block:: python
 
    trainer.logger.log_file("config.yaml")
-   trainer.logger.log_media("sample", "output.png", step=10)
+   trainer.logger.log_model_artifact("checkpoints/best.ckpt", version="best")
+
+For media uploads, use the standalone
+:class:`~litlogger.experiment.Experiment` API directly. The upstream
+:class:`lightning:lightning.pytorch.loggers.LitLogger` does not provide a
+``log_media`` helper.
 
 Runnable Example
 ================

--- a/docs/source/tutorials/lightning.rst
+++ b/docs/source/tutorials/lightning.rst
@@ -64,7 +64,10 @@ Enable automatic checkpoint uploads with ``log_model=True``.
 Files and Media
 ===============
 
-The logger also exposes helper methods for artifact and media logging:
+The logger also exposes
+:meth:`~litlogger.logger.LightningLogger.log_file` and
+:meth:`~litlogger.logger.LightningLogger.log_media` for artifact and media
+logging:
 
 .. code-block:: python
 

--- a/docs/source/tutorials/quickstart.rst
+++ b/docs/source/tutorials/quickstart.rst
@@ -15,13 +15,15 @@ Create an Experiment
 
    experiment = litlogger.init(name="quickstart")
 
-``litlogger.init()`` returns an :class:`~litlogger.experiment.Experiment`
-instance. That object is the main entrypoint for the new API.
+:func:`litlogger.init() <litlogger.init.init>` returns an
+:class:`~litlogger.experiment.Experiment` instance. That object is the main
+entrypoint for the new API.
 
 Log Metadata
 ============
 
-Static string assignments become experiment metadata:
+Static string assignments become
+:attr:`~litlogger.experiment.Experiment.metadata` entries:
 
 .. code-block:: python
 
@@ -33,7 +35,8 @@ Log Metrics
 ===========
 
 Time-series metrics use :class:`~litlogger.series.Series` through
-``experiment["key"].append(...)`` or ``extend(...)``:
+:meth:`~litlogger.series.Series.append` or
+:meth:`~litlogger.series.Series.extend` on ``experiment["key"]``:
 
 .. code-block:: python
 
@@ -61,7 +64,11 @@ Use :class:`~litlogger.media.File` for static artifacts:
 Inspect Logged Data
 ===================
 
-The experiment exposes runtime views for metadata, metrics, and artifacts:
+The experiment exposes runtime views through
+:attr:`~litlogger.experiment.Experiment.metadata`,
+:attr:`~litlogger.experiment.Experiment.metrics`,
+:attr:`~litlogger.experiment.Experiment.artifacts`, and
+:attr:`~litlogger.experiment.Experiment.url`:
 
 .. code-block:: python
 
@@ -72,6 +79,8 @@ The experiment exposes runtime views for metadata, metrics, and artifacts:
 
 Finalize
 ========
+
+Use :meth:`~litlogger.experiment.Experiment.finalize` when the run is complete.
 
 .. code-block:: python
 


### PR DESCRIPTION
Changes plain-text/code-style hightlights to proper cross-references where applicable.