### PR TITLE
docs: Propose some docs updates

### DIFF
--- a/docs/source/guide/artifacts.rst
+++ b/docs/source/guide/artifacts.rst
@@ -7,8 +7,8 @@ your experiments. The modern path is the file-like API with
 :class:`~litlogger.media.File` and :class:`~litlogger.media.Model`, while the
 older helper methods remain available for compatibility.
 
-New Dict-Style API
-==================
+Using the Experiment API
+========================
 
 Use the returned :class:`~litlogger.experiment.Experiment` and assign
 file-like wrappers directly:

--- a/docs/source/guide/media.rst
+++ b/docs/source/guide/media.rst
@@ -6,8 +6,8 @@ LitLogger supports uploading images and text files that are displayed alongside
 your metrics in the experiment view. For new code, prefer the dict-style
 wrappers :class:`~litlogger.media.Image` and :class:`~litlogger.media.Text`.
 
-New Dict-Style API
-==================
+Using the Experiment API
+========================
 
 .. code-block:: python
 

--- a/docs/source/guide/standalone.rst
+++ b/docs/source/guide/standalone.rst
@@ -12,8 +12,8 @@ recommended standalone workflow is the dict-style
    :width: 800px
    :align: center
 
-Recommended New API
-===================
+Using the Experiment API
+========================
 
 .. code-block:: python
 
@@ -34,11 +34,11 @@ Recommended New API
 
 The new standalone API covers:
 
-- metadata through ``experiment["key"] = "value"``
-- metrics through :meth:`~litlogger.series.Series.append` and
+- Setting metadata with ``experiment["key"] = "value"``
+- Logging metrics with :meth:`~litlogger.series.Series.append` and
   :meth:`~litlogger.series.Series.extend`
-- artifacts, media, and models through file-like wrappers
-- retrieval through :attr:`~litlogger.experiment.Experiment.metadata`,
+- Logging artifacts, media, and models through file-like wrappers
+- Retrieving logged data through :attr:`~litlogger.experiment.Experiment.metadata`,
   :attr:`~litlogger.experiment.Experiment.metrics`, and
   :attr:`~litlogger.experiment.Experiment.artifacts`
 
@@ -119,7 +119,7 @@ The older module-level API is still available for compatibility through
    litlogger.log_metadata({"model": "resnet50"})
    litlogger.finalize()
 
-This API is useful for existing scripts, but the dict-style API is the primary
+This API is useful for existing scripts, but the dict-style :class:`~litlogger.experiment.Experiment` API is the primary
 user-facing workflow.
 
 Operational Options

--- a/docs/source/guide/workflows.rst
+++ b/docs/source/guide/workflows.rst
@@ -6,22 +6,22 @@ Workflows
 This guide maps the LitLogger feature set to concrete workflows so users can
 quickly choose the right API surface.
 
-Standalone New API
-==================
+Experiment API
+==============
 
 Recommended for new code.
 
-- initialize with :func:`litlogger.init.init`
-- work with the returned :class:`~litlogger.experiment.Experiment`
-- log metadata with ``experiment["key"] = "value"``
-- log metrics with :meth:`~litlogger.series.Series.append` and
+- Initialize with :func:`litlogger.init.init`
+- Work with the returned :class:`~litlogger.experiment.Experiment`
+- Log metadata with ``experiment["key"] = "value"``
+- Log metrics with :meth:`~litlogger.series.Series.append` and
   :meth:`~litlogger.series.Series.extend` on ``experiment["key"]``
-- log files, media, and models with the file-like wrappers
+- Log files, media, and models with the file-like wrappers
 
 Legacy Module-Level API
 =======================
 
-Supported for existing standalone scripts, but the dict-style API is the main
+Supported for existing standalone scripts, but the Experiment API is the main
 user-facing API going forward.
 
 - :func:`~litlogger.log_metrics`
@@ -30,8 +30,8 @@ user-facing API going forward.
 - :func:`~litlogger.log_model_artifact`
 - :func:`~litlogger.log_metadata`
 
-Lightning and Fabric
-====================
+PyTorch Lightning and Lightning Fabric
+======================================
 
 Use :class:`lightning:lightning.pytorch.loggers.LitLogger` with a Trainer or
 Fabric loop. The local :class:`~litlogger.logger.LightningLogger` alias is

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,23 +1,17 @@
-######################
-Experiment Management
-######################
+##################################
+Experiment Tracking with LitLogger
+##################################
 
-LitLogger is the experiment tracker built into Lightning AI. It supports
-standalone scripts, the new dict-style
-:class:`~litlogger.experiment.Experiment` API, Lightning/Fabric integration,
-files, media, models, and retrieval workflows.
+LitLogger is the experiment tracker built into Lightning AI.
+Instrument your code with metrics, upload media and artifacts,
+and then visualize these over time inside the Lightning AI platform.
+LitLogger can be integrated into standalone scripts,
+or works seamlessly with PyTorch Lightning and Lightning Fabric.
 
 .. image:: https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/litlogger/experiment_comparison_charts.png
    :alt: Comparing experiment metrics with charts
    :width: 800px
    :align: center
-
-These docs are organized as a narrative:
-
-- tutorials to get from zero to a working flow
-- guides for specific workflows and API patterns
-- runnable examples from the repository
-- an API reference for the public surface
 
 Start Here
 ==========
@@ -33,38 +27,45 @@ Use this path if you are new to LitLogger:
 Supported Workflows
 ===================
 
-LitLogger currently supports these main workflows:
+LitLogger supports several key workflows:
 
-- standalone logging with the dict-style
-  :class:`~litlogger.experiment.Experiment` API
-- legacy module-level logging helpers for existing scripts
-- Lightning and Fabric integration through upstream
-  :class:`lightning:lightning.pytorch.loggers.LitLogger`
-- file, image, text, and model logging through
-  :class:`~litlogger.media.File`, :class:`~litlogger.media.Image`,
-  :class:`~litlogger.media.Text`, and :class:`~litlogger.media.Model`
-- experiment resume and later retrieval by name through
-  :func:`litlogger.init.init`
-- inference logging from a LitServe endpoint
+- Start or resume an :class:`~litlogger.experiment.Experiment` with :func:`litlogger.init.init`
+- Log numeric metrics, :class:`~litlogger.media.Model` or :class:`~litlogger.media.File` artifacts, and media such as :class:`~litlogger.media.Image` and
+  :class:`~litlogger.media.Text`
+- Integrate seamlessly with PyTorch Lightning or Lightning Fabric using the
+  :class:`lightning:lightning.pytorch.loggers.LitLogger` API
+- Log inference metrics from :doc:`LitServe <tutorials/litserve>`
 
 Quick Example
 =============
 
 .. code-block:: python
 
-   import litlogger
-   from litlogger import File, Text
+    import litlogger
+    from litlogger import Text, File, Model, Image
 
-   experiment = litlogger.init(name="quickstart")
+    # Create or resume an experiment with an optional name
+    experiment = litlogger.init(name="quickstart")
 
-   experiment["model"] = "resnet50"
-   experiment["notes"] = Text("first run")
+    # Set experiment-level metadata, media, or artifacts
+    experiment["model_name"] = "resnet50"
+    # experiment["model"] = Model(<filepath or object>)
+    # experiment["config"] = File(<filepath>)
 
-   for step in range(10):
-       experiment["train/loss"].append(1.0 / (step + 1), step=step)
+    # Use append to log metrics or media at each step or epoch
+    global_step = 0
+    for epoch in range(5):
+        for step in range(10):
+            experiment["epoch"].append(epoch, step=global_step)
+            experiment["train/loss"].append(1.0 / (global_step + 1), step=global_step)
+            global_step += 1
 
-   experiment["config"] = File("config.yaml")
-   experiment.finalize()
+        # experiment["validation_image"].append(Image(<filepath or object>), step=global_step)
+
+    experiment["summary"] = Text(f"Completed {global_step} steps across {epoch} epochs")
+
+    # Manually mark the experiment as complete
+    experiment.finalize()
 
 Documentation Map
 =================

--- a/docs/source/tutorials/complete_workflow.rst
+++ b/docs/source/tutorials/complete_workflow.rst
@@ -4,11 +4,11 @@ Complete Workflow
 
 This tutorial covers a full experiment lifecycle:
 
-1. initialize a run
-2. log metadata, metrics, and artifacts
-3. finalize
-4. reconnect later
-5. retrieve metadata and files
+1. Initialize a run
+2. Log metadata, metrics, and artifacts
+3. Finalize
+4. Reconnect later
+5. Retrieve metadata and files
 
 .. image:: https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/litlogger/experiment_comparison_charts.png
    :alt: Comparing experiment metrics with charts
@@ -32,12 +32,12 @@ Fetch Script
 What This Covers
 ================
 
-- experiment creation by name
-- metadata logging
-- metric logging
-- artifact upload
-- reconnection to an existing experiment
-- file download and metadata access
+- Create experiment by name
+- Log metadata
+- Log metrics
+- Upload artifacts
+- Reconnect to an existing experiment
+- Download files and access metadata
 
 Related Guides
 ==============

--- a/docs/source/tutorials/lightning.rst
+++ b/docs/source/tutorials/lightning.rst
@@ -3,7 +3,7 @@ Lightning Tutorial
 ##################
 
 Use :class:`lightning:lightning.pytorch.loggers.LitLogger` when you want
-Lightning or Fabric to drive experiment logging for you.
+PyTorch Lightning or Lightning Fabric to drive experiment logging for you.
 :class:`~litlogger.logger.LightningLogger` is deprecated and remains only as a
 compatibility alias.
 

--- a/docs/source/tutorials/litserve.rst
+++ b/docs/source/tutorials/litserve.rst
@@ -22,10 +22,10 @@ for each request in ``predict()``.
 What This Workflow Covers
 =========================
 
-- request-time metric logging
-- inference latency tracking
-- token-count or request-shape metrics
-- deployment-oriented usage outside training loops
+- Request-time metric logging
+- Inference latency tracking
+- Token-count or request-shape metrics
+- Deployment-oriented usage outside training loops
 
 Related Docs
 ============

--- a/docs/source/tutorials/quickstart.rst
+++ b/docs/source/tutorials/quickstart.rst
@@ -2,7 +2,7 @@
 Quickstart
 ##########
 
-This tutorial introduces the new dict-style API through the smallest useful
+This tutorial introduces the Experiment API through the smallest useful
 workflow: create an experiment, log metadata and metrics, upload a file, and
 finalize the run.
 


### PR DESCRIPTION
General patterns applied:
* Start bullets with capitals
* Prefer present-tense verbs for describing what can be done
* Remove reference to "New" Experiment API; just advise it as the primary API