### PR TITLE
Remove remaining trackers references

### DIFF
--- a/src/litlogger/api/metrics_api.py
+++ b/src/litlogger/api/metrics_api.py
@@ -17,15 +17,12 @@ import contextlib
 import os
 from typing import Any
 
-from google.protobuf import timestamp_pb2
-from google.protobuf.json_format import MessageToDict
 from lightning_sdk.lightning_cloud.openapi import (
     LitLoggerServiceAppendLoggerMetricsBody,
     LitLoggerServiceCreateMetricsStreamBody,
     LitLoggerServiceUpdateMetricsStreamBody,
     V1Metrics,
     V1MetricsTags,
-    V1MetricsTracker,
     V1MetricValue,
     V1PhaseType,
     V1SystemInfo,
@@ -34,7 +31,7 @@ from lightning_sdk.lightning_cloud.openapi import (
 from litlogger.api.client import LitRestClient
 from litlogger.colors import _create_colors
 from litlogger.diagnostics import collect_system_info
-from litlogger.types import Metrics, MetricsTracker, MetricValue, PhaseType
+from litlogger.types import Metrics, MetricValue, PhaseType
 
 
 # Translation functions between user-facing models and V1 models
@@ -59,64 +56,6 @@ def _to_v1_metrics(metrics: Metrics) -> V1Metrics:
     """Convert user-facing Metrics to V1Metrics."""
     v1_values = [_to_v1_metric_value(v) for v in metrics.values]
     return V1Metrics(name=metrics.name, values=v1_values)
-
-
-def _to_v1_metrics_tracker(tracker: MetricsTracker) -> V1MetricsTracker:
-    """Convert user-facing MetricsTracker to V1MetricsTracker."""
-    started_at_val = None
-    if tracker.started_at:
-        # Convert datetime to protobuf Timestamp format
-        timestamp = timestamp_pb2.Timestamp()
-        timestamp.FromDatetime(tracker.started_at)
-        started_at_val = MessageToDict(timestamp)
-
-    updated_at_val = None
-    if tracker.updated_at:
-        # Convert datetime to protobuf Timestamp format
-        timestamp = timestamp_pb2.Timestamp()
-        timestamp.FromDatetime(tracker.updated_at)
-        updated_at_val = MessageToDict(timestamp)
-
-    # Build kwargs, excluding None values that the API might not accept
-    kwargs = {
-        "name": tracker.name,
-        "num_rows": tracker.num_rows,
-    }
-    if tracker.min_value is not None:
-        kwargs["min_value"] = tracker.min_value
-    if tracker.max_value is not None:
-        kwargs["max_value"] = tracker.max_value
-    if tracker.min_index is not None:
-        kwargs["min_index"] = tracker.min_index
-    if tracker.max_index is not None:
-        kwargs["max_index"] = tracker.max_index
-    if tracker.last_value is not None:
-        kwargs["last_value"] = tracker.last_value
-    if tracker.last_index is not None:
-        kwargs["last_index"] = tracker.last_index
-    if started_at_val is not None:
-        kwargs["started_at"] = started_at_val
-    if updated_at_val is not None:
-        kwargs["updated_at"] = updated_at_val
-    if tracker.max_user_step is not None:
-        kwargs["max_user_step"] = tracker.max_user_step
-
-    return V1MetricsTracker(**kwargs)
-
-
-def _from_v1_metrics_tracker(v1_tracker: V1MetricsTracker) -> MetricsTracker:
-    """Convert V1MetricsTracker from API response to user-facing MetricsTracker."""
-    return MetricsTracker(
-        name=v1_tracker.name,
-        num_rows=v1_tracker.num_rows or 0,
-        min_value=v1_tracker.min_value,
-        max_value=v1_tracker.max_value,
-        min_index=v1_tracker.min_index,
-        max_index=v1_tracker.max_index,
-        last_value=v1_tracker.last_value,
-        last_index=v1_tracker.last_index,
-        max_user_step=v1_tracker.max_user_step,
-    )
 
 
 def _to_v1_phase_type(phase: PhaseType) -> str:
@@ -304,10 +243,9 @@ class MetricsApi:
         metrics_store_id: str,
         persisted: bool = True,
         phase: PhaseType = PhaseType.COMPLETED,
-        trackers: dict[str, MetricsTracker] | None = None,
         metadata: dict[str, str] | None = None,
     ) -> None:
-        """Update an experiment metrics store with completion status, trackers, and/or metadata.
+        """Update an experiment metrics store with completion status, and/or metadata.
 
         When ``metadata`` is ``None`` (the default), existing tags on the server are
         left untouched.  Pass an explicit dict to replace the tags.
@@ -317,15 +255,11 @@ class MetricsApi:
             metrics_store_id: The metrics store ID.
             persisted: Whether the metrics have been persisted.
             phase: The phase of the metrics store (e.g., COMPLETED).
-            trackers: Optional dictionary of metric trackers.
             metadata: Optional metadata to attach to the experiment. If None,
                 existing tags are preserved.
         """
-        # Convert user-facing phase and trackers to V1 types
+        # Convert user-facing phase to V1 types
         v1_phase = _to_v1_phase_type(phase)
-        v1_trackers = None
-        if trackers:
-            v1_trackers = {name: _to_v1_metrics_tracker(tracker) for name, tracker in trackers.items()}
 
         self.client.lit_logger_service_update_metrics_stream(
             project_id=teamspace_id,
@@ -333,7 +267,6 @@ class MetricsApi:
             body=LitLoggerServiceUpdateMetricsStreamBody(
                 persisted=persisted,
                 phase=v1_phase,
-                trackers=v1_trackers,
                 tags=self._metadata_to_tags(metadata=metadata) if metadata is not None else None,
             ),
         )
@@ -362,20 +295,6 @@ class MetricsApi:
             with contextlib.suppress(TypeError, ValueError):
                 result[name] = int(last_step)
         return result
-
-    def get_trackers_from_metrics_store(self, metrics_store: Any) -> dict[str, MetricsTracker] | None:
-        """Extract and convert trackers from a metrics store object.
-
-        Args:
-            metrics_store: The metrics store object from the API.
-
-        Returns:
-            Dictionary of MetricsTracker objects, or None if no trackers exist.
-        """
-        if not hasattr(metrics_store, "trackers") or not metrics_store.trackers:
-            return None
-
-        return {name: _from_v1_metrics_tracker(v1_tracker) for name, v1_tracker in metrics_store.trackers.items()}
 
     @staticmethod
     def _metadata_to_tags(metadata: dict[str, Any] | None) -> list[V1MetricsTags]:

--- a/src/litlogger/background.py
+++ b/src/litlogger/background.py
@@ -230,7 +230,7 @@ class _BackgroundThread(Thread):
     def inform_done(self) -> None:
         """Inform the API that metrics collection is complete.
 
-        Sends the final update with phase=COMPLETED and accumulated trackers.
+        Sends the final update with phase=COMPLETED.
         Metadata is intentionally omitted (None) so that tags set via
         ``Experiment.log_metadata`` are preserved.
         """

--- a/src/litlogger/experiment.py
+++ b/src/litlogger/experiment.py
@@ -158,6 +158,7 @@ class Experiment(LegacyExperiment):
         self._metrics_queue: JoinableQueue[dict[str, Metrics]] = JoinableQueue()
         self._stop_event = Event()
         self._is_ready_event = Event()
+        self._resumed_steps = self._metrics_api.get_last_steps(self._teamspace.id, self._metrics_store.id) or {}
         self._manager = _BackgroundThread(
             teamspace_id=self._teamspace.id,
             metrics_store_id=self._metrics_store.id,
@@ -170,7 +171,7 @@ class Experiment(LegacyExperiment):
             store_created_at=bool(store_created_at),
             rate_limiting_interval=rate_limiting_interval,
             max_batch_size=max_batch_size,
-            last_steps=self._metrics_api.get_last_steps(self._teamspace.id, self._metrics_store.id),
+            last_steps=self._resumed_steps,
         )
 
         self._manager.start()

--- a/src/litlogger/experiment_support.py
+++ b/src/litlogger/experiment_support.py
@@ -143,7 +143,7 @@ class ExperimentStateSupport:
 
     @staticmethod
     def rebuild_state(exp: "Experiment") -> None:
-        """Rebuild state from remote metadata, trackers, artifacts, and media.
+        """Rebuild state from remote metadata, steps, artifacts, and media.
 
         TODO: Add backend-supported recovery for model bindings so resumed
         experiments can reconstruct ``Model`` values without storing them in
@@ -156,10 +156,8 @@ class ExperimentStateSupport:
                 exp._key_types[tag.name] = "metadata"
                 exp._metadata_values[tag.name] = tag.value
 
-        trackers = exp._metrics_api.get_trackers_from_metrics_store(exp._metrics_store)
-        if trackers:
-            for name in trackers:
-                exp._key_types[name] = "metric"
+        for name in exp._resumed_steps:
+            exp._key_types[name] = "metric"
 
         artifacts = getattr(exp._metrics_store, "artifacts", None) or []
         with contextlib.suppress(AttributeError):

--- a/src/litlogger/types.py
+++ b/src/litlogger/types.py
@@ -67,34 +67,3 @@ class Metrics:
 
     name: str
     values: list[MetricValue] = field(default_factory=list)
-
-
-@dataclass
-class MetricsTracker:
-    """Tracks statistics about a metric series.
-
-    Attributes:
-        name: The metric name.
-        num_rows: Total number of values logged.
-        min_value: Minimum value observed.
-        max_value: Maximum value observed.
-        min_index: Index where minimum value occurred.
-        max_index: Index where maximum value occurred.
-        last_value: Most recent value.
-        last_index: Index of most recent value.
-        started_at: Datetime when tracking started.
-        updated_at: Datetime of last update.
-        max_user_step: Maximum user-provided step value.
-    """
-
-    name: str
-    num_rows: int = 0
-    min_value: float | None = None
-    max_value: float | None = None
-    min_index: int | None = None
-    max_index: int | None = None
-    last_value: float | None = None
-    last_index: int | None = None
-    started_at: datetime | None = None
-    updated_at: datetime | None = None
-    max_user_step: int | None = None

--- a/tests/integrations/test_standalone_lifecycle.py
+++ b/tests/integrations/test_standalone_lifecycle.py
@@ -188,8 +188,8 @@ def test_custom_colors():
 
 
 @pytest.mark.cloud()
-def test_resume_experiment_with_tracker_initialization():
-    """Test that resuming an experiment initializes trackers and augments steps correctly."""
+def test_resume_experiment():
+    """Test that resuming an experiment augments steps correctly."""
     experiment_name = f"standalone_resume_tracker-{uuid.uuid4().hex}"
 
     # First experiment run - log metrics with explicit steps

--- a/tests/unittests/api/test_metrics_api.py
+++ b/tests/unittests/api/test_metrics_api.py
@@ -8,12 +8,11 @@ from unittest.mock import MagicMock, patch
 
 from lightning_sdk.lightning_cloud.openapi import (
     V1Metrics,
-    V1MetricsTracker,
     V1MetricValue,
     V1PhaseType,
 )
-from litlogger.api.metrics_api import MetricsApi, _from_v1_metrics_tracker
-from litlogger.types import MetricsTracker, PhaseType
+from litlogger.api.metrics_api import MetricsApi
+from litlogger.types import PhaseType
 
 
 class TestMetricsApi:
@@ -290,51 +289,6 @@ class TestMetricsApi:
         assert call_args.kwargs["id"] == "ms-456"
         assert call_args.kwargs["body"].persisted is True
         assert call_args.kwargs["body"].phase == V1PhaseType.COMPLETED
-        assert call_args.kwargs["body"].trackers is None
-
-    def test_update_experiment_metrics_with_trackers(self):
-        """Test updating experiment metrics with trackers."""
-        mock_client = MagicMock()
-        api = MetricsApi(client=mock_client)
-
-        # Use user-facing types
-        trackers = {
-            "loss": MetricsTracker(
-                name="loss",
-                num_rows=100,
-                min_value=0.1,
-                max_value=1.0,
-                last_value=0.3,
-            ),
-            "accuracy": MetricsTracker(
-                name="accuracy",
-                num_rows=100,
-                min_value=0.8,
-                max_value=0.99,
-                last_value=0.95,
-            ),
-        }
-
-        api.update_experiment_metrics(
-            teamspace_id="ts-123",
-            metrics_store_id="ms-456",
-            persisted=True,
-            phase=PhaseType.COMPLETED,
-            trackers=trackers,
-        )
-
-        # Verify client was called correctly
-        mock_client.lit_logger_service_update_metrics_stream.assert_called_once()
-        call_args = mock_client.lit_logger_service_update_metrics_stream.call_args
-
-        assert call_args.kwargs["project_id"] == "ts-123"
-        assert call_args.kwargs["id"] == "ms-456"
-        assert call_args.kwargs["body"].persisted is True
-        # The API translates PhaseType.COMPLETED to V1PhaseType.COMPLETED
-        assert call_args.kwargs["body"].phase == V1PhaseType.COMPLETED
-        # Trackers should be translated to V1MetricsTracker
-        assert "loss" in call_args.kwargs["body"].trackers
-        assert "accuracy" in call_args.kwargs["body"].trackers
 
     def test_update_experiment_metrics_custom_phase(self):
         """Test updating experiment metrics with custom phase."""
@@ -352,136 +306,3 @@ class TestMetricsApi:
         call_args = mock_client.lit_logger_service_update_metrics_stream.call_args
         assert call_args.kwargs["body"].persisted is False
         assert call_args.kwargs["body"].phase == V1PhaseType.RUNNING
-
-
-class TestFromV1MetricsTracker:
-    """Test the _from_v1_metrics_tracker helper function."""
-
-    def test_converts_full_tracker(self):
-        """Test converting a V1MetricsTracker with all fields set."""
-        v1_tracker = V1MetricsTracker(
-            name="loss",
-            num_rows=100,
-            min_value=0.1,
-            max_value=1.0,
-            min_index=50,
-            max_index=0,
-            last_value=0.2,
-            last_index=99,
-            max_user_step=99,
-        )
-
-        result = _from_v1_metrics_tracker(v1_tracker)
-
-        assert isinstance(result, MetricsTracker)
-        assert result.name == "loss"
-        assert result.num_rows == 100
-        assert result.min_value == 0.1
-        assert result.max_value == 1.0
-        assert result.min_index == 50
-        assert result.max_index == 0
-        assert result.last_value == 0.2
-        assert result.last_index == 99
-        assert result.max_user_step == 99
-
-    def test_converts_minimal_tracker(self):
-        """Test converting a V1MetricsTracker with only required fields."""
-        v1_tracker = MagicMock()
-        v1_tracker.name = "accuracy"
-        v1_tracker.num_rows = None
-        v1_tracker.min_value = None
-        v1_tracker.max_value = None
-        v1_tracker.min_index = None
-        v1_tracker.max_index = None
-        v1_tracker.last_value = None
-        v1_tracker.last_index = None
-        v1_tracker.max_user_step = None
-
-        result = _from_v1_metrics_tracker(v1_tracker)
-
-        assert isinstance(result, MetricsTracker)
-        assert result.name == "accuracy"
-        assert result.num_rows == 0  # Defaults to 0 when None
-        assert result.min_value is None
-        assert result.max_value is None
-
-    def test_converts_tracker_with_zero_num_rows(self):
-        """Test converting a tracker with explicit zero num_rows."""
-        v1_tracker = V1MetricsTracker(
-            name="metric",
-            num_rows=0,
-        )
-
-        result = _from_v1_metrics_tracker(v1_tracker)
-
-        assert result.num_rows == 0
-
-
-class TestGetTrackersFromMetricsStore:
-    """Test the get_trackers_from_metrics_store method."""
-
-    def test_returns_none_when_no_trackers_attribute(self):
-        """Test returns None when metrics store has no trackers attribute."""
-        mock_client = MagicMock()
-        api = MetricsApi(client=mock_client)
-
-        mock_metrics_store = MagicMock(spec=[])  # No attributes
-
-        result = api.get_trackers_from_metrics_store(mock_metrics_store)
-
-        assert result is None
-
-    def test_returns_none_when_trackers_is_none(self):
-        """Test returns None when metrics store trackers is None."""
-        mock_client = MagicMock()
-        api = MetricsApi(client=mock_client)
-
-        mock_metrics_store = MagicMock()
-        mock_metrics_store.trackers = None
-
-        result = api.get_trackers_from_metrics_store(mock_metrics_store)
-
-        assert result is None
-
-    def test_returns_none_when_trackers_is_empty(self):
-        """Test returns None when metrics store trackers is empty dict."""
-        mock_client = MagicMock()
-        api = MetricsApi(client=mock_client)
-
-        mock_metrics_store = MagicMock()
-        mock_metrics_store.trackers = {}
-
-        result = api.get_trackers_from_metrics_store(mock_metrics_store)
-
-        assert result is None
-
-    def test_converts_trackers_from_metrics_store(self):
-        """Test successfully converts trackers from metrics store."""
-        mock_client = MagicMock()
-        api = MetricsApi(client=mock_client)
-
-        mock_metrics_store = MagicMock()
-        mock_metrics_store.trackers = {
-            "loss": V1MetricsTracker(
-                name="loss",
-                num_rows=100,
-                min_value=0.1,
-                max_value=1.0,
-            ),
-            "accuracy": V1MetricsTracker(
-                name="accuracy",
-                num_rows=50,
-                min_value=0.8,
-                max_value=0.99,
-            ),
-        }
-
-        result = api.get_trackers_from_metrics_store(mock_metrics_store)
-
-        assert result is not None
-        assert len(result) == 2
-        assert "loss" in result
-        assert "accuracy" in result
-        assert isinstance(result["loss"], MetricsTracker)
-        assert result["loss"].num_rows == 100
-        assert result["accuracy"].num_rows == 50

--- a/tests/unittests/test_experiment_media.py
+++ b/tests/unittests/test_experiment_media.py
@@ -607,7 +607,7 @@ class TestRebuildStateFiles:
         exp._update_metrics_store = MagicMock()
         exp._metrics_store.tags = []
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_trackers_from_metrics_store.return_value = []
+        exp._resumed_steps = {}
 
         art = MagicMock()
         art.path = "results.csv"
@@ -635,12 +635,12 @@ class TestRebuildStateFiles:
         exp._teamspace = MagicMock()
         exp._teamspace.id = "ts-1"
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_trackers_from_metrics_store.return_value = []
         art = MagicMock()
         art.path = "results.csv"
         exp._metrics_api.client.lit_logger_service_list_logger_artifacts.return_value.logger_artifacts = [art]
         exp._update_metrics_store = MagicMock()
         exp._create_download_fn = lambda key: lambda path: f"dl:{key}:{path}"
+        exp._resumed_steps = {}
 
         Experiment._rebuild_state(exp)
 
@@ -660,7 +660,6 @@ class TestRebuildStateFiles:
         exp._teamspace = MagicMock()
         exp._teamspace.id = "ts-1"
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_trackers_from_metrics_store.return_value = []
         art0 = MagicMock()
         art0.path = "reports/0"
         art1 = MagicMock()
@@ -668,6 +667,7 @@ class TestRebuildStateFiles:
         exp._metrics_api.client.lit_logger_service_list_logger_artifacts.return_value.logger_artifacts = [art1, art0]
         exp._update_metrics_store = MagicMock()
         exp._create_download_fn = lambda key: lambda path: f"dl:{key}:{path}"
+        exp._resumed_steps = {}
 
         Experiment._rebuild_state(exp)
 
@@ -685,7 +685,7 @@ class TestRebuildStateFiles:
         exp._update_metrics_store = MagicMock()
         exp._metrics_store.tags = []
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_trackers_from_metrics_store.return_value = []
+        exp._resumed_steps = {}
 
         art = MagicMock()
         art.path = "existing"
@@ -717,7 +717,6 @@ class TestRebuildStateFiles:
         exp._metrics_store.tags = []
         exp._metrics_store.artifacts = []
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_trackers_from_metrics_store.return_value = []
         exp._teamspace = MagicMock()
         exp._teamspace.id = "ts-1"
         exp._media_api = MagicMock()
@@ -726,6 +725,7 @@ class TestRebuildStateFiles:
         exp._create_media_download_fn = lambda storage_path, cloud_account=None: Experiment._create_media_download_fn(
             exp, storage_path, cloud_account
         )
+        exp._resumed_steps = {}
 
         Experiment._rebuild_state(exp)
 
@@ -760,7 +760,6 @@ class TestRebuildStateFiles:
         exp._metrics_store.tags = []
         exp._metrics_store.artifacts = []
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_trackers_from_metrics_store.return_value = []
         exp._teamspace = MagicMock()
         exp._teamspace.id = "ts-1"
         exp._media_api = MagicMock()
@@ -769,6 +768,7 @@ class TestRebuildStateFiles:
         exp._create_media_download_fn = lambda storage_path, cloud_account=None: Experiment._create_media_download_fn(
             exp, storage_path, cloud_account
         )
+        exp._resumed_steps = {}
 
         Experiment._rebuild_state(exp)
 
@@ -805,7 +805,6 @@ class TestRebuildStateFiles:
         exp._metrics_store.tags = []
         exp._metrics_store.artifacts = []
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_trackers_from_metrics_store.return_value = []
         exp._teamspace = MagicMock()
         exp._teamspace.id = "ts-1"
         exp._media_api = MagicMock()
@@ -814,6 +813,7 @@ class TestRebuildStateFiles:
         exp._create_media_download_fn = lambda storage_path, cloud_account=None: Experiment._create_media_download_fn(
             exp, storage_path, cloud_account
         )
+        exp._resumed_steps = {}
 
         Experiment._rebuild_state(exp)
 

--- a/tests/unittests/test_experiment_metadata.py
+++ b/tests/unittests/test_experiment_metadata.py
@@ -218,7 +218,6 @@ class TestRebuildStateMetadata:
         exp._static_files = {}
         exp._series = {}
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_trackers_from_metrics_store.return_value = []
 
         tag = MagicMock()
         tag.name = "model"
@@ -234,6 +233,7 @@ class TestRebuildStateMetadata:
         exp._metrics_store.tags = [tag, non_code_tag]
         exp._metrics_store.artifacts = []
         exp._create_download_fn = MagicMock()
+        exp._resumed_steps = {}
 
         Experiment._rebuild_state(exp)
 
@@ -252,8 +252,8 @@ class TestRebuildStateMetadata:
         exp._metrics_store.tags = []
         exp._metrics_store.artifacts = []
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_trackers_from_metrics_store.return_value = ["loss", "acc"]
         exp._create_download_fn = MagicMock()
+        exp._resumed_steps = {"loss": 10, "acc": 5}
 
         Experiment._rebuild_state(exp)
 

--- a/tests/unittests/test_experiment_support.py
+++ b/tests/unittests/test_experiment_support.py
@@ -117,7 +117,6 @@ class TestExperimentStateSupport:
         exp._metrics_store.tags = []
         exp._metrics_store.artifacts = []
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_trackers_from_metrics_store.return_value = []
         exp._teamspace = MagicMock()
         exp._teamspace.id = "ts-1"
         exp._media_api = MagicMock()
@@ -128,10 +127,12 @@ class TestExperimentStateSupport:
         exp._create_media_download_fn = lambda storage_path, cloud_account=None: (
             ExperimentStateSupport.create_media_download_fn(exp, storage_path, cloud_account)
         )
+        exp._resumed_steps = {"loss": 10}
 
         ExperimentStateSupport.rebuild_state(exp)
 
         assert exp._key_types["logs"] == "file_series"
+        assert exp._key_types["loss"] == "metric"
         assert isinstance(exp._series["logs"], Series)
         assert [item.path for item in exp._series["logs"]] == ["logs/0", "logs/1"]
 
@@ -162,7 +163,6 @@ class TestExperimentStateSupport:
         exp._metrics_store.tags = []
         exp._metrics_store.artifacts = []
         exp._metrics_api = MagicMock()
-        exp._metrics_api.get_trackers_from_metrics_store.return_value = []
         exp._teamspace = MagicMock()
         exp._teamspace.id = "ts-1"
         exp._media_api = MagicMock()
@@ -173,9 +173,11 @@ class TestExperimentStateSupport:
         exp._create_media_download_fn = lambda storage_path, cloud_account=None: (
             ExperimentStateSupport.create_media_download_fn(exp, storage_path, cloud_account)
         )
+        exp._resumed_steps = {"loss": 10}
 
         ExperimentStateSupport.rebuild_state(exp)
 
         assert exp._key_types["logs"] == "file_series"
+        assert exp._key_types["loss"] == "metric"
         assert isinstance(exp._series["logs"], Series)
         assert [item.path for item in exp._series["logs"]] == ["logs", "logs"]


### PR DESCRIPTION
Remove all the remaining references to trackers. The only functional change is that we now use the result of `exp._metrics_api.get_last_steps` to populate `exp._key_types` for a resumed experiment.