### PR TITLE
feat(lit-logger): metrics show metrics

### DIFF
--- a/src/litlogger/experiment_support.py
+++ b/src/litlogger/experiment_support.py
@@ -152,8 +152,18 @@ class ExperimentStateSupport:
                 exp._key_types[tag.name] = "metadata"
                 exp._metadata_values[tag.name] = tag.value
 
+        response = exp._metrics_api.client.lit_logger_service_get_logger_metrics(
+            project_id=exp._teamspace.id, ids=[exp._metrics_store.id]
+        )
         for name in exp._resumed_steps:
             exp._key_types[name] = "metric"
+            series = Series(exp, name)
+            series._type = "metric"
+            if name in response.named_metrics:
+                id_metrics = response.named_metrics[name].ids_metrics
+                metrics_values = next(iter(id_metrics.values())).metrics_values
+                series._values = [mv.value for mv in metrics_values]
+            exp._series[name] = series
 
         artifacts = getattr(exp._metrics_store, "artifacts", None) or []
         with contextlib.suppress(AttributeError):

--- a/tests/unittests/test_experiment_media.py
+++ b/tests/unittests/test_experiment_media.py
@@ -734,6 +734,14 @@ class TestRebuildStateFiles:
         exp._metrics_store.tags = []
         exp._metrics_api = MagicMock()
         exp._resumed_steps = {}
+        exp._teamspace = MagicMock()
+        exp._teamspace.id = "ts-1"
+        exp._media_api = MagicMock()
+        exp._media_api.client.lit_logger_service_list_lit_logger_media.return_value.media = []
+        response = MagicMock()
+        response.named_metrics = {}
+        exp._metrics_api.client.lit_logger_service_get_logger_metrics.return_value = response
+        exp._metrics_store.id = "store-1"
 
         art = MagicMock()
         art.path = "results.csv"
@@ -812,6 +820,14 @@ class TestRebuildStateFiles:
         exp._metrics_store.tags = []
         exp._metrics_api = MagicMock()
         exp._resumed_steps = {}
+        exp._teamspace = MagicMock()
+        exp._teamspace.id = "ts-1"
+        exp._media_api = MagicMock()
+        exp._media_api.client.lit_logger_service_list_lit_logger_media.return_value.media = []
+        response = MagicMock()
+        response.named_metrics = {}
+        exp._metrics_api.client.lit_logger_service_get_logger_metrics.return_value = response
+        exp._metrics_store.id = "store-1"
 
         art = MagicMock()
         art.path = "existing"

--- a/tests/unittests/test_experiment_metadata.py
+++ b/tests/unittests/test_experiment_metadata.py
@@ -219,6 +219,12 @@ class TestRebuildStateMetadata:
         exp._series = {}
         exp._metrics_api = MagicMock()
 
+        exp._teamspace = MagicMock()
+        exp._teamspace.id = "ts-1"
+        exp._update_metrics_store = MagicMock()
+        exp._media_api = MagicMock()
+        exp._media_api.client.lit_logger_service_list_lit_logger_media.return_value.media = []
+
         tag = MagicMock()
         tag.name = "model"
         tag.value = "resnet50"
@@ -254,6 +260,11 @@ class TestRebuildStateMetadata:
         exp._metrics_api = MagicMock()
         exp._create_download_fn = MagicMock()
         exp._resumed_steps = {"loss": 10, "acc": 5}
+        exp._teamspace = MagicMock()
+        exp._teamspace.id = "ts-1"
+        exp._update_metrics_store = MagicMock()
+        exp._media_api = MagicMock()
+        exp._media_api.client.lit_logger_service_list_lit_logger_media.return_value.media = []
 
         Experiment._rebuild_state(exp)
 

--- a/tests/unittests/test_experiment_support.py
+++ b/tests/unittests/test_experiment_support.py
@@ -208,3 +208,45 @@ class TestExperimentStateSupport:
         assert exp._key_types["loss"] == "metric"
         assert isinstance(exp._series["logs"], Series)
         assert [item.path for item in exp._series["logs"]] == ["logs", "logs"]
+
+    def test_rebuild_state_hydrates_metric_values_from_api(self):
+        mv0 = MagicMock()
+        mv0.value = 1.0
+        mv1 = MagicMock()
+        mv1.value = 0.5
+        mv2 = MagicMock()
+        mv2.value = 0.333
+
+        id_metrics_entry = MagicMock()
+        id_metrics_entry.metrics_values = [mv0, mv1, mv2]
+
+        named_metric = MagicMock()
+        named_metric.ids_metrics = {"test-id": id_metrics_entry}
+
+        response = MagicMock()
+        response.named_metrics = {"train/loss": named_metric}
+
+        exp = MagicMock(spec=Experiment)
+        exp._key_types = {}
+        exp._metadata_values = {}
+        exp._static_files = {}
+        exp._series = {}
+        exp._metrics_store = MagicMock()
+        exp._metrics_store.id = "store-1"
+        exp._metrics_store.tags = []
+        exp._metrics_store.artifacts = []
+        exp._metrics_api = MagicMock()
+        exp._metrics_api.client.lit_logger_service_get_logger_metrics.return_value = response
+        exp._teamspace = MagicMock()
+        exp._teamspace.id = "ts-1"
+        exp._media_api = MagicMock()
+        exp._media_api.client.lit_logger_service_list_lit_logger_media.return_value.media = []
+        exp._resumed_steps = {"train/loss": 2}
+
+        ExperimentStateSupport.rebuild_state(exp)
+
+        assert exp._key_types["train/loss"] == "metric"
+        series = exp._series["train/loss"]
+        assert isinstance(series, Series)
+        assert series._type == "metric"
+        assert series._values == [1.0, 0.5, 0.333]


### PR DESCRIPTION
Users can access their metrics through `.metrics`.