### PR TITLE
feat: add assertion for light/dark color list length parity

### DIFF
--- a/src/litlogger/colors.py
+++ b/src/litlogger/colors.py
@@ -223,6 +223,12 @@ _DARK_THEME_COLORS = [
 ]
 
 
+assert len(_LIGHT_THEME_COLORS) == len(_DARK_THEME_COLORS), (
+    f"Light and dark theme color lists must have the same length, "
+    f"got {len(_LIGHT_THEME_COLORS)=} and {len(_DARK_THEME_COLORS)=}"
+)
+
+
 def _create_colors(name: str | None = None) -> tuple[str, str]:
     """Return a pair of (light_mode_color, dark_mode_color).
 


### PR DESCRIPTION
## What does this PR do?

Adds a module-level assertion to verify that `_LIGHT_THEME_COLORS` and
`_DARK_THEME_COLORS` have the same length.

## Why is this needed?

`_create_colors` computes an index against `len(_DARK_THEME_COLORS)` and
uses it to index into both lists. If the two lists ever diverge in length
due to an accidental edit, the function would silently return a mismatched
color pair or raise an `IndexError` at runtime with no clear indication of
the root cause.

A module-level assertion catches this at import time, failing loudly and
immediately.

## Changes

- Added `assert len(_LIGHT_THEME_COLORS) == len(_DARK_THEME_COLORS)` with
  a descriptive error message after the color list definitions in
  `colors.py`