### PR TITLE
Don't insert line breaks in long URLs

### DIFF
--- a/src/litlogger/printer.py
+++ b/src/litlogger/printer.py
@@ -111,7 +111,7 @@ def _rich_to_str(*renderables: Any, force_terminal: bool = False) -> str:
 
     with open(os.devnull, "w") as f:
         console = Console(file=f, record=True, force_terminal=force_terminal)
-        console.print(*renderables)
+        console.print(*renderables, soft_wrap=True)
     return console.export_text(styles=True)
 
 


### PR DESCRIPTION
By default, `rich` automatically wraps text according to the console width by inserting new lines. This applies to the URLs that we render, and doesn't account for the prefix that we add later, so the end result is that URLs longer than the terminal width are unclickable and look a bit broken, e.g.:

```
           #               
       #########           
   #################       
############# #########    
##########   ##########    litlogger: 🚀 Experiment initialized
########    ###########                        Name: model-training/my-first-experiment-2026-05-26T11-44-36.416+00-00
###########    ########                   Teamspace: general
##########   ##########                     View at: 🔗 https://lightning.ai/lightning-ai/general/experiments/model-training%2Fmy-first-experiment-2026-05-26T11-
44-36.416%2B00-00
#########  ############    
   #################       
       #########           
           #   
```

Use `soft_wrap=True` to leave the wrapping up to the terminal.