### PR TITLE
ci: remove PR trigger from wheel publishing workflow

### DIFF
--- a/.github/workflows/push_wheel.yaml
+++ b/.github/workflows/push_wheel.yaml
@@ -1,12 +1,10 @@
 name: Push wheel
 
 # https://help.github.com/en/actions/reference/events-that-trigger-workflows
-on:  # Trigger the workflow on push or pull request, but only for the main branch
+on:
   push:
     branches: [main, "release/*"]
     tags: ["*"]
-  pull_request:
-    branches: [main]
   release:
     types: [published]
 


### PR DESCRIPTION
## What does this PR do?

Removes the pull request trigger from the wheel publishing workflow. The workflow still runs for pushes to main/release branches, tags, and published releases.

