### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -13,10 +13,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install uv and setup python
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         activate-environment: true
         python-version: "3.12"
@@ -34,7 +34,7 @@ jobs:
 
     - name: Upload docs artifact
       if: github.event_name == 'pull_request'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: docs-build
         path: docs/build/html/
@@ -46,10 +46,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install uv and setup python
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         activate-environment: true
         python-version: "3.12"
@@ -71,10 +71,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install uv and setup python
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         activate-environment: true
         python-version: "3.12"

--- a/.github/workflows/ci-examples.yaml
+++ b/.github/workflows/ci-examples.yaml
@@ -84,9 +84,9 @@ jobs:
       UV_TORCH_BACKEND: cpu
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install uv and setup python
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         activate-environment: true
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-integrations.yaml
+++ b/.github/workflows/ci-integrations.yaml
@@ -36,9 +36,9 @@ jobs:
       UV_TORCH_BACKEND: cpu
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install uv and setup python
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         activate-environment: true
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-mypy.yaml
+++ b/.github/workflows/ci-mypy.yaml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         python-version: ["3.11", "3.13"]
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install uv and setup python
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         activate-environment: true
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-unittests.yaml
+++ b/.github/workflows/ci-unittests.yaml
@@ -30,9 +30,9 @@ jobs:
       UV_TORCH_BACKEND: cpu
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install uv and setup python
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         activate-environment: true
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/general_checks.yaml
+++ b/.github/workflows/general_checks.yaml
@@ -13,15 +13,15 @@ concurrency:
 
 jobs:
   check-schema:
-    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@main
+    uses: Lightning-AI/utilities/.github/workflows/check-schema.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
       azure-dir: ''
 
   check-package:
     if: github.event.pull_request.draft == false
-    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@main
+    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
     with:
-      actions-ref: main
+      actions-ref: 86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3
       artifact-name: dist-packages-${{ github.sha }}
       import-name: "litlogger"
       install-flags: "--extra-index-url https://download.pytorch.org/whl/cpu"
@@ -32,4 +32,4 @@ jobs:
         }
 
   pre-commit:
-    uses: Lightning-AI/utilities/.github/workflows/check-precommit.yml@main
+    uses: Lightning-AI/utilities/.github/workflows/check-precommit.yml@86fe1b20b4609835ba9e8c8739cd39707ba76868 # v0.15.3

--- a/.github/workflows/push_wheel.yaml
+++ b/.github/workflows/push_wheel.yaml
@@ -20,8 +20,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v5
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.8"
         cache: "pip"
@@ -41,7 +41,7 @@ jobs:
     - name: Upload to release
       if: ${{ github.event_name == 'release' }}
       continue-on-error: true
-      uses: AButler/upload-release-assets@v3.0
+      uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
       with:
         files: "dist/*"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -50,14 +50,14 @@ jobs:
     # TODO: add back once ownership is transferred
     # - name: Publish to Test PyPI
     #   if: startsWith(github.event.ref, 'refs/tags')
-    #   uses: pypa/gh-action-pypi-publish@v1.12.4
+    #   uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
     #   with:
     #     repository_url: https://test.pypi.org/legacy/
     #     verbose: true
 
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.12.4
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
## What does this PR do?

Pins GitHub Actions and reusable workflows to verified commit SHAs for supply chain security.

This follows the same pattern as Lightning-AI/pytorch-lightning#21735.

## Pinned references

| Action / workflow | Release | Commit SHA |
| --- | --- | --- |
| actions/checkout | [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2) | de0fac2e4500dabe0009e67214ff5f5447ce83dd |
| actions/setup-python | [v6.2.0](https://github.com/actions/setup-python/releases/tag/v6.2.0) | a309ff8b426b58ec0e2a45f0f869d46889d02405 |
| astral-sh/setup-uv | [v7.6.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.6.0) | 37802adc94f370d6bfd71619e3f0bf239e1f3b78 |
| actions/upload-artifact | [v7.0.1](https://github.com/actions/upload-artifact/releases/tag/v7.0.1) | 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a |
| pypa/gh-action-pypi-publish | [v1.13.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.13.0) | ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e |
| AButler/upload-release-assets | [v3.0](https://github.com/AButler/upload-release-assets/releases/tag/v3.0) | 3d6774fae0ed91407dc5ae29d576b166536d1777 |
| Lightning-AI/utilities | [v0.15.3](https://github.com/Lightning-AI/utilities/releases/tag/v0.15.3) | 86fe1b20b4609835ba9e8c8739cd39707ba76868 |