### PR TITLE
fix(lit-logger): use teamspace upload file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 dependencies = [
     "blake3",
-    "lightning-sdk >=2026.8.05",
+    "lightning-sdk >=2026.8.5",
     "lightning-utilities<=0.15.3",
     "protobuf",
     "psutil",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 dependencies = [
     "blake3",
-    "lightning-sdk >=2026.05.12",
+    "lightning-sdk >=2026.7.21",
     "lightning-utilities<=0.15.3",
     "protobuf",
     "psutil",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 
 dependencies = [
     "blake3",
-    "lightning-sdk >=2026.7.21",
+    "lightning-sdk >=2026.8.05",
     "lightning-utilities<=0.15.3",
     "protobuf",
     "psutil",

--- a/src/litlogger/api/artifacts_api.py
+++ b/src/litlogger/api/artifacts_api.py
@@ -15,7 +15,6 @@ import os
 from typing import Any
 
 from lightning_sdk import Teamspace
-from lightning_sdk.api.utils import _BlobUploader
 from lightning_sdk.lightning_cloud.openapi import LitLoggerServiceCreateLoggerArtifactBody
 
 from litlogger.api.client import LitRestClient
@@ -203,7 +202,7 @@ class ArtifactsApi:
 
     def upload_metrics_binary(
         self,
-        teamspace_id: str,
+        teamspace: Teamspace,
         cloud_account: str,
         file_path: str,
         remote_path: str,
@@ -211,19 +210,14 @@ class ArtifactsApi:
         """Upload a metrics binary tar.gz file to the teamspace.
 
         Args:
-            teamspace_id: The teamspace ID.
+            teamspace: Teamspace object where the file will be uploaded.
             cloud_account: Cloud account identifier.
             file_path: Local path to the tar.gz file to upload.
             remote_path: Remote path where the file will be uploaded.
         """
-        client_host = self.client.api_client.configuration.host
-        endpoint_base = f"{client_host}/v1/projects/{teamspace_id}/artifacts"
-        blob_uploader = _BlobUploader(
-            client=self.client,
-            endpoint_base=endpoint_base,
+        teamspace.upload_file(
             file_path=file_path,
-            remote_path=remote_path.lstrip("/"),
+            remote_path=remote_path,
             progress_bar=False,
-            cluster_id=cloud_account,
+            cloud_account=cloud_account,
         )
-        blob_uploader()

--- a/src/litlogger/api/artifacts_api.py
+++ b/src/litlogger/api/artifacts_api.py
@@ -15,7 +15,7 @@ import os
 from typing import Any
 
 from lightning_sdk import Teamspace
-from lightning_sdk.api.utils import _FileUploader
+from lightning_sdk.api.utils import _BlobUploader
 from lightning_sdk.lightning_cloud.openapi import LitLoggerServiceCreateLoggerArtifactBody
 
 from litlogger.api.client import LitRestClient
@@ -216,12 +216,14 @@ class ArtifactsApi:
             file_path: Local path to the tar.gz file to upload.
             remote_path: Remote path where the file will be uploaded.
         """
-        file_uploader = _FileUploader(
+        client_host = self.client.api_client.configuration.host
+        endpoint_base = f"{client_host}/v1/projects/{teamspace_id}/artifacts"
+        blob_uploader = _BlobUploader(
             client=self.client,
-            teamspace_id=teamspace_id,
-            cloud_account=cloud_account,
+            endpoint_base=endpoint_base,
             file_path=file_path,
-            remote_path=remote_path,
+            remote_path=remote_path.lstrip("/"),
             progress_bar=False,
+            cluster_id=cloud_account,
         )
-        file_uploader()
+        blob_uploader()

--- a/src/litlogger/api/artifacts_api.py
+++ b/src/litlogger/api/artifacts_api.py
@@ -18,6 +18,7 @@ from lightning_sdk import Teamspace
 from lightning_sdk.lightning_cloud.openapi import LitLoggerServiceCreateLoggerArtifactBody
 
 from litlogger.api.client import LitRestClient
+from litlogger.api.utils import _resolve_teamspace
 
 
 class ArtifactsApi:
@@ -202,7 +203,7 @@ class ArtifactsApi:
 
     def upload_metrics_binary(
         self,
-        teamspace: Teamspace,
+        teamspace: str | Teamspace,
         cloud_account: str,
         file_path: str,
         remote_path: str,
@@ -210,12 +211,13 @@ class ArtifactsApi:
         """Upload a metrics binary tar.gz file to the teamspace.
 
         Args:
-            teamspace: Teamspace object where the file will be uploaded.
+            teamspace: Teamspace object, or its name, where the file will be uploaded.
             cloud_account: Cloud account identifier.
             file_path: Local path to the tar.gz file to upload.
             remote_path: Remote path where the file will be uploaded.
         """
-        teamspace.upload_file(
+        resolved_teamspace = _resolve_teamspace(teamspace)
+        resolved_teamspace.upload_file(
             file_path=file_path,
             remote_path=remote_path,
             progress_bar=False,

--- a/tests/unittests/api/test_artifacts_api.py
+++ b/tests/unittests/api/test_artifacts_api.py
@@ -173,6 +173,7 @@ class TestArtifactsApi:
     def test_upload_metrics_binary(self):
         """Test uploading metrics binary tar.gz file."""
         mock_client = MagicMock()
+        mock_client.api_client.configuration.host = "https://lightning.ai"
         api = ArtifactsApi(client=mock_client)
 
         with tempfile.NamedTemporaryFile(mode="wb", delete=False, suffix=".tar.gz") as f:
@@ -180,7 +181,7 @@ class TestArtifactsApi:
             temp_file = f.name
 
         try:
-            with patch("litlogger.api.artifacts_api._FileUploader") as mock_uploader:
+            with patch("litlogger.api.artifacts_api._BlobUploader") as mock_uploader:
                 api.upload_metrics_binary(
                     teamspace_id="ts-123",
                     cloud_account="acc-456",
@@ -188,14 +189,14 @@ class TestArtifactsApi:
                     remote_path="/litlogger/stream-789.tar.gz",
                 )
 
-                # Check that FileUploader was called with correct parameters
+                # Check that BlobUploader was called with correct parameters
                 mock_uploader.assert_called_once_with(
                     client=mock_client,
-                    teamspace_id="ts-123",
-                    cloud_account="acc-456",
+                    endpoint_base="https://lightning.ai/v1/projects/ts-123/artifacts",
                     file_path=temp_file,
-                    remote_path="/litlogger/stream-789.tar.gz",
+                    remote_path="litlogger/stream-789.tar.gz",
                     progress_bar=False,
+                    cluster_id="acc-456",
                 )
 
                 # Check that the uploader was called (executed)

--- a/tests/unittests/api/test_artifacts_api.py
+++ b/tests/unittests/api/test_artifacts_api.py
@@ -180,9 +180,7 @@ class TestArtifactsApi:
             temp_file = f.name
 
         try:
-            with patch(
-                "litlogger.api.artifacts_api._resolve_teamspace", return_value=mock_teamspace
-            ) as mock_resolve:
+            with patch("litlogger.api.artifacts_api._resolve_teamspace", return_value=mock_teamspace) as mock_resolve:
                 api.upload_metrics_binary(
                     teamspace="my-teamspace",
                     cloud_account="acc-456",

--- a/tests/unittests/api/test_artifacts_api.py
+++ b/tests/unittests/api/test_artifacts_api.py
@@ -171,7 +171,7 @@ class TestArtifactsApi:
             assert call_args[1]["cloud_account"] == "acc-default"
 
     def test_upload_metrics_binary(self):
-        """Test uploading metrics binary tar.gz file delegates to the SDK teamspace upload."""
+        """Test uploading metrics binary tar.gz resolves the teamspace and delegates to upload_file."""
         mock_teamspace = MagicMock()
         api = ArtifactsApi()
 
@@ -180,14 +180,18 @@ class TestArtifactsApi:
             temp_file = f.name
 
         try:
-            api.upload_metrics_binary(
-                teamspace=mock_teamspace,
-                cloud_account="acc-456",
-                file_path=temp_file,
-                remote_path="/litlogger/stream-789.tar.gz",
-            )
+            with patch(
+                "litlogger.api.artifacts_api._resolve_teamspace", return_value=mock_teamspace
+            ) as mock_resolve:
+                api.upload_metrics_binary(
+                    teamspace="my-teamspace",
+                    cloud_account="acc-456",
+                    file_path=temp_file,
+                    remote_path="/litlogger/stream-789.tar.gz",
+                )
 
-            # Delegates to the public teamspace upload method
+            # A teamspace name is resolved to a Teamspace, then uploaded via its public method
+            mock_resolve.assert_called_once_with("my-teamspace")
             mock_teamspace.upload_file.assert_called_once_with(
                 file_path=temp_file,
                 remote_path="/litlogger/stream-789.tar.gz",

--- a/tests/unittests/api/test_artifacts_api.py
+++ b/tests/unittests/api/test_artifacts_api.py
@@ -171,35 +171,28 @@ class TestArtifactsApi:
             assert call_args[1]["cloud_account"] == "acc-default"
 
     def test_upload_metrics_binary(self):
-        """Test uploading metrics binary tar.gz file."""
-        mock_client = MagicMock()
-        mock_client.api_client.configuration.host = "https://lightning.ai"
-        api = ArtifactsApi(client=mock_client)
+        """Test uploading metrics binary tar.gz file delegates to the SDK teamspace upload."""
+        mock_teamspace = MagicMock()
+        api = ArtifactsApi()
 
         with tempfile.NamedTemporaryFile(mode="wb", delete=False, suffix=".tar.gz") as f:
             f.write(b"compressed metrics data")
             temp_file = f.name
 
         try:
-            with patch("litlogger.api.artifacts_api._BlobUploader") as mock_uploader:
-                api.upload_metrics_binary(
-                    teamspace_id="ts-123",
-                    cloud_account="acc-456",
-                    file_path=temp_file,
-                    remote_path="/litlogger/stream-789.tar.gz",
-                )
+            api.upload_metrics_binary(
+                teamspace=mock_teamspace,
+                cloud_account="acc-456",
+                file_path=temp_file,
+                remote_path="/litlogger/stream-789.tar.gz",
+            )
 
-                # Check that BlobUploader was called with correct parameters
-                mock_uploader.assert_called_once_with(
-                    client=mock_client,
-                    endpoint_base="https://lightning.ai/v1/projects/ts-123/artifacts",
-                    file_path=temp_file,
-                    remote_path="litlogger/stream-789.tar.gz",
-                    progress_bar=False,
-                    cluster_id="acc-456",
-                )
-
-                # Check that the uploader was called (executed)
-                mock_uploader.return_value.assert_called_once()
+            # Delegates to the public teamspace upload method
+            mock_teamspace.upload_file.assert_called_once_with(
+                file_path=temp_file,
+                remote_path="/litlogger/stream-789.tar.gz",
+                progress_bar=False,
+                cloud_account="acc-456",
+            )
         finally:
             os.unlink(temp_file)


### PR DESCRIPTION
With the latest lightning-sdk(`2026.07.21`), we don't have `_FileUploader`. To prevent this from happening, this PR updates `artifacts_api.py` to use `upload_file` method rather than the internal sdk method.