### PR TITLE
fix(docs): stop rendering duplicate parameter type hints in the API reference

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -123,7 +123,11 @@ nitpick_ignore = [
 autosummary_generate = True
 autodoc_member_order = "groupwise"
 autoclass_content = "both"
-autodoc_typehints = "description"
+# Let sphinx-autodoc-typehints render hints into the documented parameters. Core autodoc's
+# "description" would render them a second time (its own target defaults to "all"), so every
+# parameter showed up twice — once with its description, once as a bare type. "none" leaves the
+# type hints entirely to the extension below.
+autodoc_typehints = "none"
 typehints_description_target = "documented_params"
 
 autodoc_default_options = {


### PR DESCRIPTION
## What

`docs/source/conf.py` enables **two** type-hint renderers at once:

- core autodoc via `autodoc_typehints = "description"`, and
- the `sphinx_autodoc_typehints` extension (with `typehints_description_target = "documented_params"`).

Both inject type hints into the parameter descriptions, so every parameter in the API reference renders **twice** — once with its description and merged type (from the extension), and once as a bare type-only entry (from core autodoc, whose own target defaults to `"all"`).

<img width="951" height="1031" alt="Screenshot 2026-07-28 at 13 19 05" src="https://github.com/user-attachments/assets/a7dcb7c4-174c-4203-ac1b-0ee1e4996452" />

## Fix

Set `autodoc_typehints = "none"` so the extension is the sole renderer. The extension already handles this correctly and honors `documented_params`.

## Effect

Built against the docs toolchain (`--group docs`, Sphinx 8.2), on the API reference page:

| | Parameter entries | With description | Bare duplicates |
| --- | --- | --- | --- |
| before | 273 | 114 | 159 |
| after | 114 | 114 | 0 |

Each parameter now appears once, keeping its description with the type merged in, e.g.:

> **name** (`str | None`) – Name of your experiment (defaults to a generated name).

`Returns` / `Return type` fields are unaffected.
