### PR TITLE
fix(litlogger): omit version suffix on model upload when not provided

### DIFF
--- a/src/litlogger/media.py
+++ b/src/litlogger/media.py
@@ -561,7 +561,7 @@ class Model(File):
     def _registry_name(self, experiment_name: str, teamspace: Teamspace) -> str:
         """Resolve the registry name for this model."""
         model_name = f"{teamspace.owner.name}/{teamspace.name}/{experiment_name}"
-        if self.version:
+        if self._version_provided:
             model_name += f":{_sanitize_version_for_model_name(self.version)}"
         return model_name
 

--- a/tests/unittests/test_media.py
+++ b/tests/unittests/test_media.py
@@ -734,6 +734,19 @@ class TestModelInit:
         assert mock_upload_model.call_args.kwargs["experiment"] is experiment
 
     @patch("litlogger.media.upload_model")
+    def test_log_model_omits_version_when_not_provided(self, mock_upload_model):
+        teamspace = MagicMock()
+        teamspace.name = "teamspace"
+        teamspace.owner.name = "owner"
+        experiment = MagicMock()
+
+        model = Model("checkpoint.ckpt")
+        model._log_model(experiment_name="exp-name", teamspace=teamspace, experiment=experiment)
+
+        assert mock_upload_model.call_args.kwargs["name"] == "owner/teamspace/exp-name"
+        assert mock_upload_model.call_args.kwargs["experiment"] is experiment
+
+    @patch("litlogger.media.upload_model")
     def test_log_model_uses_custom_name_override(self, mock_upload_model):
         teamspace = MagicMock()
         teamspace.name = "teamspace"


### PR DESCRIPTION
Closes #68

Model._registry_name checked self.version, which always defaults to latest in __init__ regardless of whether a version was actually specified. This appended a literal :latest suffix to the registry name on every upload where the caller did not set a version, and the backend rejects that suffix with a 400.

The class already tracks whether a version was explicitly provided via self._version_provided, matching the check already used by the series upload path in experiment_support.py. This switches _registry_name to check that flag instead, so an omitted version sends no suffix and lets the server auto-assign one.

Verified locally with pytest: added a test asserting the upload name has no version suffix when omitted, then reverted the one-line fix to confirm it reproduces the exact failure (owner/teamspace/exp-name:latest instead of owner/teamspace/exp-name).