### PR TITLE
build: derive versions from SCM and gate PyPI publishing

### DIFF
--- a/.github/workflows/push_wheel.yaml
+++ b/.github/workflows/push_wheel.yaml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: "3.8"
+        python-version: "3.11"
         cache: "pip"
 
     - name: Install dependencies

--- a/.github/workflows/push_wheel.yaml
+++ b/.github/workflows/push_wheel.yaml
@@ -58,6 +58,3 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/push_wheel.yaml
+++ b/.github/workflows/push_wheel.yaml
@@ -56,7 +56,7 @@ jobs:
     #     verbose: true
 
     - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.event.ref, 'refs/tags')
+      if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         user: __token__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=61.0.0",
-    "setuptools-scm>=8",
+    "setuptools-scm[simple]>=9.2",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
@@ -65,8 +65,6 @@ tests = [
     "lightning>=2.0.0",
     "torchvision"
 ]
-
-[tool.setuptools_scm]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=61.0.0",
+    "setuptools>=80",
     "setuptools-scm[simple]>=9.2",
     "wheel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=61.0.0",
+    "setuptools-scm>=8",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
@@ -65,8 +66,7 @@ tests = [
     "torchvision"
 ]
 
-[tool.setuptools.dynamic]
-version = {attr = "litlogger.__version__"}
+[tool.setuptools_scm]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/litlogger/__init__.py
+++ b/src/litlogger/__init__.py
@@ -18,7 +18,9 @@ For guides and examples, see https://lightning.ai.
 For reference documentation, see https://github.com/Lightning-AI/litlogger.
 """
 
-__version__ = "2026.08.28"
+from importlib.metadata import version
+
+__version__ = version("litlogger")
 
 # Import core classes
 # Import preinit utilities


### PR DESCRIPTION
## What

- derive package versions from Git tags with `setuptools-scm`
- expose the installed distribution version through `litlogger.__version__`
- publish to PyPI only for a published GitHub Release using OIDC Trusted Publishing, without stored PyPI credentials

## Verification

- Python 3.11 sdist and wheel build with `setuptools>=80`
- isolated wheel install/import with `litlogger.__version__` matching package metadata
- `ruff check src/litlogger/__init__.py`
- workflow YAML parse and publish-condition assertion
- `git diff --check`
