### PR TITLE
fix(ci): keep release checkout clean for SCM versioning

### DIFF
--- a/.github/workflows/push_wheel.yaml
+++ b/.github/workflows/push_wheel.yaml
@@ -29,9 +29,6 @@ jobs:
     - name: Install dependencies
       run: pip install -U setuptools wheel build
 
-    - name: Overview Readme for release
-      run: echo "# Lit Logger" > README.md
-
     - name: Build packages
       run: |
         # todo: add sdist once public


### PR DESCRIPTION
## What

- remove the release-time README rewrite so `setuptools-scm` sees a clean exact-tag checkout
- preserve the existing release-only OIDC PyPI publishing flow

## Root cause

The workflow modified `README.md` immediately before building. That made the `v2026.08.28` checkout dirty, so `setuptools-scm` generated `2026.8.29.dev0+gc5ccbd00b.d20260828`, which PyPI rejects because public uploads cannot use local version identifiers.

## Verification

- fresh shallow clone of remote tag `v2026.08.28`: `python -m setuptools_scm` returned `2026.8.28`
- Python 3.11 exact-tag wheel build produced `litlogger-2026.8.28-py3-none-any.whl`
- workflow YAML assertion
- `git diff --check`
